### PR TITLE
feat: standardize error response shape to { error: { message, code } }

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ TradeTrack is built with a focus on clean architecture, observability, and produ
 |---|---|
 | Backend | Node.js, Express |
 | Database | PostgreSQL (Docker) |
-| Frontend | React (Vite) |
+| Frontend | React (Vite), Tailwind CSS |
 | Testing | Jest, Supertest |
 | CI | GitHub Actions |
 

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -63,7 +63,7 @@ export default function Login() {
             const data = await res.json();
 
             if (!res.ok) {
-                setMessage(data.message || "Login failed");
+                setMessage(data.error?.message || "Login failed");
                 setLoading(false);
                 return;
             }

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -68,7 +68,7 @@ export default function Register() {
 
       if (!res.ok) {
         setIsSuccess(false);
-        setMessage(data.message || "Registration failed");
+        setMessage(data.error?.message || "Registration failed");
         setLoading(false);
         return;
       }

--- a/client/src/pages/TradeEntry.jsx
+++ b/client/src/pages/TradeEntry.jsx
@@ -260,7 +260,7 @@ export default function TradeEntry() {
       // API Guard
       // =========================
       if (!res.ok || data.status !== "success") {
-        console.error("API Error:", data.message);
+        setFormError(data.error?.message || "Failed to create trade");
         return;
       }
 

--- a/server/src/modules/auth/controllers/auth.controller.js
+++ b/server/src/modules/auth/controllers/auth.controller.js
@@ -61,8 +61,7 @@ const register = async (req, res) => {
     const error = validateLogin({ email, password });
     if (error) {
       return res.status(400).json({
-        status: "error",
-        message: error,
+        error: { message: error, code: "VALIDATION_ERROR" },
       });
     }
 
@@ -79,10 +78,11 @@ const register = async (req, res) => {
     logger.error("Registration failed", { error: err.message });
 
     const statusCode = err.status || 500;
+    const message = statusCode === 500 ? "Internal server error" : err.message;
+    const code = err.code || (statusCode === 500 ? "INTERNAL_ERROR" : "ERROR");
 
     return res.status(statusCode).json({
-      status: "error",
-      message: statusCode === 500 ? "Internal server error" : err.message,
+      error: { message, code },
     });
   }
 };
@@ -101,8 +101,7 @@ const login = async (req, res) => {
   const error = validateLogin({ email, password });
   if (error) {
     return res.status(400).json({
-      status: "error",
-      message: error,
+      error: { message: error, code: "VALIDATION_ERROR" },
     });
   }
 
@@ -112,8 +111,7 @@ const login = async (req, res) => {
 
     if (!user) {
       return res.status(401).json({
-        status: "error",
-        message: "Invalid credentials",
+        error: { message: "Invalid credentials", code: "INVALID_CREDENTIALS" },
       });
     }
 
@@ -135,8 +133,7 @@ const login = async (req, res) => {
     logger.error("Login failed", { error: err.message });
 
     return res.status(500).json({
-      status: "error",
-      message: "Internal server error",
+      error: { message: "Internal server error", code: "INTERNAL_ERROR" },
     });
   }
 };
@@ -184,8 +181,7 @@ const handleLogout = async (req, res) => {
 const getMe = (req, res) => {
   if (!req.userId) {
     return res.status(401).json({
-      status: "error",
-      message: "Unauthorized",
+      error: { message: "Unauthorized", code: "UNAUTHORIZED" },
     });
   }
 

--- a/server/src/modules/trades/controllers/trades.controller.js
+++ b/server/src/modules/trades/controllers/trades.controller.js
@@ -21,13 +21,17 @@ const sendSuccess = (res, { statusCode = 200, message, data }) => {
  */
 const sendError = (res, err) => {
   const statusCode = err.status || 500;
+  const message =
+    statusCode === 500
+      ? "Internal server error"
+      : err.message || "Something went wrong";
+  const code = err.code || (statusCode === 500 ? "INTERNAL_ERROR" : "ERROR");
 
   return res.status(statusCode).json({
-    status: "error",
-    message:
-      statusCode === 500
-        ? "Internal server error"
-        : err.message || "Something went wrong",
+    error: {
+      message,
+      code,
+    },
   });
 };
 

--- a/server/src/utils/dbErrorHandler.js
+++ b/server/src/utils/dbErrorHandler.js
@@ -1,0 +1,110 @@
+// /server/src/utils/dbErrorHandler.js
+
+const createLogger = require("./logger");
+
+const logger = createLogger("db.error.handler");
+
+/**
+ * =========================================================
+ * DATABASE ERROR HANDLER
+ * =========================================================
+ *
+ * PURPOSE:
+ * Maps PostgreSQL error codes to meaningful HTTP errors.
+ * Prevents raw Postgres errors from surfacing as 500s.
+ *
+ * =========================================================
+ * POSTGRES ERROR CODES:
+ * 23505 — unique_violation      (duplicate key)
+ * 23502 — not_null_violation    (missing required field)
+ * 23503 — foreign_key_violation (invalid foreign key reference)
+ *
+ * =========================================================
+ * USAGE:
+ * Call handleDbError(error) in any repository catch block.
+ * It will throw a structured error or re-throw the original.
+ * =========================================================
+ */
+
+/**
+ * Maps a PostgreSQL error to a structured application error.
+ * Throws a structured error with status, code, and message.
+ * Re-throws the original error if unrecognized.
+ *
+ * @param {Error} error - The raw error from PostgreSQL
+ * @throws {Error} - Structured error with status and code
+ */
+const handleDbError = (error) => {
+  logger.debug("Handling database error", { pgCode: error.code });
+
+  switch (error.code) {
+
+    // ----------------------------------------------------------
+    // 23505 — Unique Violation
+    // Triggered when a duplicate value violates a unique constraint
+    // e.g. duplicate email on register
+    // ----------------------------------------------------------
+    case "23505": {
+      const field = extractField(error.detail);
+      const err = new Error(
+        field ? `${field} already exists` : "A record with that value already exists"
+      );
+      err.status = 409;
+      err.code = "DUPLICATE_ERROR";
+      logger.warn("Unique constraint violation", { field, detail: error.detail });
+      throw err;
+    }
+
+    // ----------------------------------------------------------
+    // 23502 — Not Null Violation
+    // Triggered when a required field is missing
+    // ----------------------------------------------------------
+    case "23502": {
+      const field = error.column || "unknown field";
+      const err = new Error(`${field} is required`);
+      err.status = 400;
+      err.code = "NOT_NULL_ERROR";
+      logger.warn("Not null constraint violation", { field });
+      throw err;
+    }
+
+    // ----------------------------------------------------------
+    // 23503 — Foreign Key Violation
+    // Triggered when a referenced record does not exist
+    // e.g. trade inserted with invalid user_id
+    // ----------------------------------------------------------
+    case "23503": {
+      const err = new Error("Referenced record does not exist");
+      err.status = 400;
+      err.code = "FOREIGN_KEY_ERROR";
+      logger.warn("Foreign key constraint violation", { detail: error.detail });
+      throw err;
+    }
+
+    // ----------------------------------------------------------
+    // Unrecognized error — re-throw as-is
+    // Will be caught by the global error handler as a 500
+    // ----------------------------------------------------------
+    default:
+      logger.error("Unrecognized database error", {
+        pgCode: error.code,
+        message: error.message,
+      });
+      throw error;
+  }
+};
+
+/**
+ * Extracts the field name from a Postgres error detail string.
+ * e.g. 'Key (email)=(test@test.com) already exists.' → 'email'
+ *
+ * @param {string} detail - Postgres error detail string
+ * @returns {string|null} - Extracted field name or null
+ */
+const extractField = (detail) => {
+  if (!detail) return null;
+  const match = detail.match(/Key \((.+?)\)=/);
+  return match ? match[1] : null;
+};
+
+module.exports = { handleDbError };

--- a/server/tests/api/app.test.js
+++ b/server/tests/api/app.test.js
@@ -122,13 +122,11 @@ describe("App Infrastructure", () => {
       .post("/api/trades")
       .set("Cookie", cookie)
       .send(validTrade());
-  
+
     // Use the same cookie for the GET — the session must remain
     // valid between the POST and GET within the same test.
-    const res = await request(app)
-      .get("/api/trades")
-      .set("Cookie", cookie);
-  
+    const res = await request(app).get("/api/trades").set("Cookie", cookie);
+
     expect(res.status).toBe(200);
     expect(res.body.data.length).toBe(1);
   });
@@ -142,8 +140,10 @@ describe("App Infrastructure", () => {
    *
    * EXPECTED FORMAT:
    * {
-   *   status: "error",
-   *   message: string
+   *   error: {
+   *     message: string,
+   *     code: string
+   *   }
    * }
    *
    * WHY:
@@ -157,8 +157,9 @@ describe("App Infrastructure", () => {
       .send({});
 
     expect(res.status).toBe(400);
-    expect(res.body).toHaveProperty("status", "error");
-    expect(res.body).toHaveProperty("message");
+    expect(res.body).toHaveProperty("error");
+    expect(res.body.error).toHaveProperty("message");
+    expect(res.body.error).toHaveProperty("code");
   });
 
   // =========================

--- a/server/tests/api/trades.test.js
+++ b/server/tests/api/trades.test.js
@@ -104,8 +104,8 @@ describe("Trade API", () => {
       .send(invalidTrade());
 
     expect(res.status).toBe(400);
-    expect(res.body.status).toBe("error");
-    expect(res.body.message).toMatch(/required/i);
+    expect(res.body.error).toBeDefined();
+    expect(res.body.error.message).toMatch(/required/i);
   });
 
   // =========================
@@ -139,7 +139,7 @@ describe("Trade API", () => {
       });
 
     expect(res.status).toBe(400);
-    expect(res.body.message).toMatch(/greater than 0|invalid numeric/i);
+    expect(res.body.error.message).toMatch(/greater than 0|invalid numeric/i);
   });
 
   // =========================
@@ -174,7 +174,7 @@ describe("Trade API", () => {
       });
 
     expect(res.status).toBe(400);
-    expect(res.body.message).toMatch(/exit.*both|incomplete/i);
+    expect(res.body.error.message).toMatch(/exit.*both|incomplete/i);
   });
 
   // =========================
@@ -245,7 +245,7 @@ describe("Trade API", () => {
         });
 
       expect(res.status).toBe(400);
-      expect(res.body.message).toMatch(/invalid trade type/i);
+      expect(res.body.error.message).toMatch(/invalid trade type/i);
     }
   });
 });


### PR DESCRIPTION
closes #43 

## Summary
Standardizes all error responses across the backend to a consistent shape and updates the frontend to consume the new format.

## Changes

### Backend

**trades.controller.js**
- Updated `sendError` helper to return `{ error: { message, code } }`
- 500 errors return generic message, never stack traces or raw DB errors
- Error code derived from `err.code` or defaults to `INTERNAL_ERROR`

**auth.controller.js**
- Updated all error responses to return `{ error: { message, code } }`
- Validation errors return `VALIDATION_ERROR` code
- Invalid credentials return `INVALID_CREDENTIALS` code with 401
- Unauthorized returns `UNAUTHORIZED` code with 401
- 500 errors return `INTERNAL_ERROR` code with generic message
