### PR TITLE
feat: add validation and error handling tests

### DIFF
--- a/server/src/modules/trades/validation/trades.validation.js
+++ b/server/src/modules/trades/validation/trades.validation.js
@@ -31,7 +31,8 @@ function validateTrade(trade) {
     return createValidationError("Invalid payload");
   }
 
-  const { symbol, type, entryPrice, quantity, exitPrice, exitTime } = trade;
+  const { symbol, type, entryPrice, quantity, exitPrice, exitTime, entryTime } =
+    trade;
 
   // =========================
   // Required fields
@@ -104,6 +105,16 @@ function validateTrade(trade) {
     return createValidationError(
       "Exit price and exit time must both be provided",
       "exit",
+    );
+  }
+
+  // =========================
+  // Temporal validation
+  // =========================
+  if (entryTime && exitTime && new Date(exitTime) <= new Date(entryTime)) {
+    return createValidationError(
+      "Exit time must be after entry time",
+      "exitTime",
     );
   }
 

--- a/server/tests/api/auth.test.js
+++ b/server/tests/api/auth.test.js
@@ -174,4 +174,124 @@ describe("Authentication System", () => {
     const res = await request(app).get("/api/trades").set("Cookie", cookie);
     expect(res.status).toBe(200);
   });
+
+  // =========================
+  // Test Case 3.8
+  // Duplicate Email Registration
+  // =========================
+  /**
+   * Ensures that registering with an existing email
+   * returns a 409 Conflict.
+   *
+   * WHY:
+   * - Validates duplicate email constraint handling
+   * - Confirms structured error response shape
+   */
+  it("rejects duplicate email registration", async () => {
+    // Register first user
+    await request(app)
+      .post("/api/auth/register")
+      .send({ email: "duplicate@example.com", password: "Password1!" });
+
+    // Attempt duplicate registration
+    const res = await request(app)
+      .post("/api/auth/register")
+      .send({ email: "duplicate@example.com", password: "Password1!" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBeDefined();
+    expect(res.body.error.message).toMatch(/already exists/i);
+    expect(res.body.error.code).toBe("DUPLICATE_ERROR");
+  });
+
+  // =========================
+  // Test Case 3.9
+  // Login With Wrong Password
+  // =========================
+  /**
+   * Ensures that login with incorrect password
+   * returns a 401 Unauthorized.
+   *
+   * WHY:
+   * - Validates credential verification logic
+   * - Confirms error shape on auth failure
+   */
+  it("rejects login with wrong password", async () => {
+    const res = await request(app)
+      .post("/api/auth/login")
+      .send({ email: "test@example.com", password: "WrongPassword1!" });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBeDefined();
+    expect(res.body.error.message).toMatch(/invalid credentials/i);
+    expect(res.body.error.code).toBe("INVALID_CREDENTIALS");
+  });
+
+  // =========================
+  // Test Case 3.10
+  // Login With Non-Existent Email
+  // =========================
+  /**
+   * Ensures that login with an unregistered email
+   * returns a 401 Unauthorized.
+   *
+   * WHY:
+   * - Validates that non-existent users are rejected
+   * - Confirms same error shape as wrong password
+   *   to prevent email enumeration
+   */
+  it("rejects login with non-existent email", async () => {
+    const res = await request(app)
+      .post("/api/auth/login")
+      .send({ email: "nobody@example.com", password: "Password1!" });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBeDefined();
+    expect(res.body.error.message).toMatch(/invalid credentials/i);
+    expect(res.body.error.code).toBe("INVALID_CREDENTIALS");
+  });
+
+  // =========================
+  // Test Case 3.11
+  // Register With Missing Email
+  // =========================
+  /**
+   * Ensures that registration without an email
+   * returns a 400 Bad Request.
+   *
+   * WHY:
+   * - Validates required field enforcement
+   * - Confirms error shape on validation failure
+   */
+  it("rejects registration with missing email", async () => {
+    const res = await request(app)
+      .post("/api/auth/register")
+      .send({ password: "Password1!" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  // =========================
+  // Test Case 3.12
+  // Register With Missing Password
+  // =========================
+  /**
+   * Ensures that registration without a password
+   * returns a 400 Bad Request.
+   *
+   * WHY:
+   * - Validates required field enforcement
+   * - Confirms error shape on validation failure
+   */
+  it("rejects registration with missing password", async () => {
+    const res = await request(app)
+      .post("/api/auth/register")
+      .send({ email: "test@example.com" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
 });

--- a/server/tests/api/trades.test.js
+++ b/server/tests/api/trades.test.js
@@ -248,4 +248,92 @@ describe("Trade API", () => {
       expect(res.body.error.message).toMatch(/invalid trade type/i);
     }
   });
+
+  // =========================
+  // Test Case 1.7
+  // Negative Exit Price
+  // =========================
+  /**
+   * Validates that a negative exit price is rejected.
+   *
+   * WHY:
+   * - Prevents invalid financial data
+   * - Enforces positive number constraint on exit price
+   */
+  it("rejects negative exit price", async () => {
+    const res = await request(app)
+      .post("/api/trades")
+      .set("Cookie", cookie)
+      .send({
+        symbol: "AAPL",
+        type: "BUY",
+        entryPrice: 100,
+        exitPrice: -50,
+        quantity: 1,
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+    expect(res.body.error.message).toMatch(/greater than 0/i);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  // =========================
+  // Test Case 1.8
+  // Zero Quantity
+  // =========================
+  /**
+   * Validates that a zero quantity is rejected.
+   *
+   * WHY:
+   * - A trade with zero quantity is meaningless
+   * - Enforces positive integer constraint on quantity
+   */
+  it("rejects zero quantity", async () => {
+    const res = await request(app)
+      .post("/api/trades")
+      .set("Cookie", cookie)
+      .send({
+        symbol: "AAPL",
+        type: "BUY",
+        entryPrice: 100,
+        quantity: 0,
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+    expect(res.body.error.message).toMatch(/greater than 0/i);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  // =========================
+  // Test Case 1.9
+  // Exit Time Before Entry Time
+  // =========================
+  /**
+   * Validates that exit time cannot be before entry time.
+   *
+   * WHY:
+   * - A trade cannot close before it opens
+   * - Enforces temporal integrity of trade lifecycle
+   */
+  it("rejects exit time before entry time", async () => {
+    const res = await request(app)
+      .post("/api/trades")
+      .set("Cookie", cookie)
+      .send({
+        symbol: "AAPL",
+        type: "BUY",
+        entryPrice: 100,
+        exitPrice: 110,
+        quantity: 1,
+        entryTime: "2024-01-10T10:00:00",
+        exitTime: "2024-01-09T10:00:00",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+    expect(res.body.error.message).toMatch(/exit time/i);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
 });

--- a/server/tests/fixtures/trades.js
+++ b/server/tests/fixtures/trades.js
@@ -6,6 +6,7 @@ function validTrade(overrides = {}) {
     type: "BUY",
     entryPrice: 100,
     quantity: 1,
+    entryTime: "2026-04-21T09:00:00Z",
     exitPrice: 150,
     exitTime: "2026-04-21T10:00:00Z",
     ...overrides,


### PR DESCRIPTION
closes #44 

## Summary
Adds comprehensive test coverage for validation and error handling across auth and trade endpoints. Also adds missing temporal validation to the backend trade validation layer.

## Changes

### tests/api/auth.test.js
- Test 3.8 — rejects duplicate email registration → 409
- Test 3.9 — rejects login with wrong password → 401
- Test 3.10 — rejects login with non-existent email → 401
- Test 3.11 — rejects registration with missing email → 400
- Test 3.12 — rejects registration with missing password → 400

### tests/api/trades.test.js
- Test 1.7 — rejects negative exit price → 400
- Test 1.8 — rejects zero quantity → 400
- Test 1.9 — rejects exit time before entry time → 400

### tests/fixtures/trades.js
- Added `entryTime` to `validTrade` fixture to satisfy temporal validation

### trades.validation.js
- Added `entryTime` to destructuring
- Added temporal validation — exit time must be after entry time

## Test Count
- Previously: 21 tests
- Now: 29 tests

## Acceptance Criteria
- [x] Tests exist for each invalid input scenario in trades and auth
- [x] Tests assert correct HTTP status codes and error message shape
- [x] Tests cover Postgres constraint violations (duplicate email, missing fields)
- [x] All 29 tests pass in CI