### PR TITLE
feat: add close trade endpoint (PATCH /api/trades/:id/close)

### DIFF
--- a/client/src/components/CloseTradeModal.jsx
+++ b/client/src/components/CloseTradeModal.jsx
@@ -1,0 +1,87 @@
+// /client/src/components/CloseTradeModal.jsx
+
+import { useState } from "react";
+import { formatQuantity } from "../utils/formatters";
+
+/**
+ * Modal to confirm and submit close trade action
+ *
+ * @param {Object}   trade        - The trade being closed
+ * @param {Function} onConfirm    - Called with (tradeId, exitPrice, exitTime)
+ * @param {Function} onCancel     - Called when user dismisses the modal
+ * @param {boolean}  isSubmitting - Disables confirm button during request
+ * @param {string}   error        - Error message to display inside modal
+ */
+export default function CloseTradeModal({ trade, onConfirm, onCancel, isSubmitting, error }) {
+  const [exitPrice, setExitPrice] = useState("");
+  const [exitTime, setExitTime]   = useState("");
+
+  const handleSubmit = () => {
+    onConfirm(trade.trade_id, exitPrice, exitTime);
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50">
+      <div className="bg-zinc-900 border border-zinc-700 rounded-2xl p-6 w-full max-w-md space-y-5">
+
+        <div>
+          <h2 className="text-lg font-semibold text-white">Close Trade</h2>
+          <p className="text-sm text-zinc-400 mt-1">
+            {trade.symbol} · {trade.trade_type} · {formatQuantity(trade.quantity)} lot
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          <div>
+            <label className="block text-xs text-zinc-400 uppercase tracking-wider mb-1.5">
+              Exit Price
+            </label>
+            <input
+              type="number"
+              value={exitPrice}
+              onChange={(e) => setExitPrice(e.target.value)}
+              placeholder="e.g. 19600.00"
+              className="w-full bg-zinc-800 border border-zinc-700 text-white placeholder-zinc-600 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent transition"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs text-zinc-400 uppercase tracking-wider mb-1.5">
+              Exit Time
+            </label>
+            <input
+              type="datetime-local"
+              value={exitTime}
+              onChange={(e) => setExitTime(e.target.value)}
+              className="w-full bg-zinc-800 border border-zinc-700 text-white rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent transition"
+            />
+          </div>
+        </div>
+
+        {error && (
+          <p className="text-sm text-red-400 bg-red-950 border border-red-800 rounded-lg px-4 py-2.5">
+            {error}
+          </p>
+        )}
+
+        <div className="flex justify-end gap-3 pt-1">
+          <button
+            onClick={onCancel}
+            disabled={isSubmitting}
+            className="text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-500 rounded-lg px-4 py-2 transition"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={isSubmitting}
+            className="bg-emerald-500 hover:bg-emerald-400 disabled:opacity-50 text-zinc-950 font-semibold rounded-lg px-5 py-2 text-sm transition"
+          >
+            {isSubmitting ? "Closing..." : "Confirm Close"}
+          </button>
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/TradeEntry.jsx
+++ b/client/src/pages/TradeEntry.jsx
@@ -13,6 +13,8 @@ import {
   validateExitAfterEntry,
   validateExitFields
 } from "../utils/validation";
+import { formatCurrency, formatPrice, formatQuantity, formatDateTime } from "../utils/formatters";
+import CloseTradeModal from "../components/CloseTradeModal";
 
 /**
  * =========================================================
@@ -84,6 +86,10 @@ export default function TradeEntry() {
    */
   const [trades, setTrades] = useState([]);
 
+  const [closingTrade, setClosingTrade]       = useState(null);  // trade being closed
+  const [closeError, setCloseError]           = useState("");
+  const [closeSubmitting, setCloseSubmitting] = useState(false);
+
   // =========================================================
   // LOGOUT
   // =========================================================
@@ -99,25 +105,6 @@ export default function TradeEntry() {
   // =========================
   // Helpers
   // =========================
-
-  /**
-   * Formats a number into USD currency string
-   * Adds "+" sign for positive values
-   */
-  const formatCurrency = (value) => {
-    if (value == null) return "Open";
-
-    const sign = value > 0 ? "+" : "";
-
-    return (
-      sign +
-      value.toLocaleString("en-US", {
-        style: "currency",
-        currency: "USD",
-        minimumFractionDigits: 2
-      })
-    );
-  };
 
   /**
    * UI color based on P&L
@@ -141,41 +128,6 @@ export default function TradeEntry() {
       ? (t.exit_price - t.entry_price)
       : (t.entry_price - t.exit_price);
     return diff * t.quantity * multiplier;
-  };
-
-  /**
-   * Formats an ISO datetime string into a readable short format
-   * e.g. "Jan 5, 02:30 PM"
-   */
-  const formatDateTime = (iso) => {
-    if (!iso) return "—";
-    return new Date(iso).toLocaleString("en-US", {
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit"
-    });
-  };
-
-  /**
-   * Formats a numeric price to 2 decimal places
-   * e.g. 19500.2500 → "19,500.25"
-   */
-  const formatPrice = (value) => {
-    if (value == null) return "—";
-    return Number(value).toLocaleString("en-US", {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2
-    });
-  };
-
-  /**
-   * Formats quantity as a whole number integer
-   * e.g. 1.0000 → "1"
-   */
-  const formatQuantity = (value) => {
-    if (value == null) return "—";
-    return parseInt(value, 10).toString();
   };
 
   // =========================
@@ -290,6 +242,42 @@ export default function TradeEntry() {
     }
   };
 
+  /**
+   * Submit close trade request to backend
+   * Updates trade row in place on success
+   */
+  const handleCloseTrade = async (tradeId, exitPrice, exitTime) => {
+    setCloseError("");
+    setCloseSubmitting(true);
+
+    try {
+      const res = await fetch(`${API_URL}/api/trades/${tradeId}/close`, {
+        method: "PATCH",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ exitPrice: Number(exitPrice), exitTime }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok || data.status !== "success") {
+        setCloseError(data.error?.message || "Failed to close trade");
+        return;
+      }
+
+      // Update the row in place — no re-fetch needed
+      setTrades((prev) =>
+        prev.map((t) => (t.trade_id === tradeId ? data.data : t))
+      );
+
+      setClosingTrade(null);
+    } catch (err) {
+      console.error("Close trade error:", err);
+      setCloseError("Network error. Please try again.");
+    } finally {
+      setCloseSubmitting(false);
+    }
+  };
 
   // =========================
   // Effects
@@ -532,14 +520,16 @@ export default function TradeEntry() {
           <div className="bg-zinc-900 border border-zinc-800 rounded-2xl overflow-hidden">
 
             {/* TABLE HEADER */}
-            <div className="grid grid-cols-7 gap-4 px-6 py-3 border-b border-zinc-800 text-xs text-zinc-500 uppercase tracking-wider">
+            <div className="grid grid-cols-9 gap-4 px-6 py-3 border-b border-zinc-800 text-xs text-zinc-500 uppercase tracking-wider">
               <span>Symbol</span>
               <span>Type</span>
               <span>Entry Time</span>
               <span>Entry Price</span>
+              <span>Exit Time</span>
               <span>Exit Price</span>
               <span>Qty</span>
               <span className="text-right">P&L</span>
+              <span></span>
             </div>
 
             {/* TRADE ROWS */}
@@ -555,7 +545,7 @@ export default function TradeEntry() {
                 return (
                   <div
                     key={t.trade_id || `${t.symbol}-${t.entry_time}`}
-                    className="grid grid-cols-7 gap-4 px-6 py-4 border-b border-zinc-800 last:border-0 hover:bg-zinc-800/50 transition text-sm"
+                    className="grid grid-cols-9 gap-4 px-6 py-4 border-b border-zinc-800 last:border-0 hover:bg-zinc-800/50 transition text-sm items-center"
                   >
                     <span className="font-medium text-white">{t.symbol}</span>
 
@@ -567,13 +557,26 @@ export default function TradeEntry() {
 
                     <span className="text-zinc-300">{formatPrice(t.entry_price)}</span>
 
+                    <span className="text-zinc-400">{formatDateTime(t.exit_time)}</span>
+
                     <span className="text-zinc-300">{t.exit_price != null ? formatPrice(t.exit_price) : "—"}</span>
 
                     <span className="text-zinc-400">{formatQuantity(t.quantity)}</span>
 
-                    <span className={`text-right font-medium ${isOpen ? "text-zinc-500" : getPnlColor(pnl)}`}>
+                    <span className={`text-right font-medium ${isOpen ? "text-amber-400" : getPnlColor(pnl)}`}>
                       {isOpen ? "Open" : formatCurrency(pnl)}
                     </span>
+
+                    <div className="flex justify-end">
+                      {isOpen && (
+                        <button
+                          onClick={() => { setCloseError(""); setClosingTrade(t); }}
+                          className="text-xs text-zinc-400 hover:text-emerald-400 border border-zinc-700 hover:border-emerald-500 rounded-md px-3 py-1 transition"
+                        >
+                          Close
+                        </button>
+                      )}
+                    </div>
                   </div>
                 );
               })
@@ -581,7 +584,15 @@ export default function TradeEntry() {
 
           </div>
         </section>
-
+        {closingTrade && (
+          <CloseTradeModal
+            trade={closingTrade}
+            onConfirm={handleCloseTrade}
+            onCancel={() => { setClosingTrade(null); setCloseError(""); }}
+            isSubmitting={closeSubmitting}
+            error={closeError}
+          />
+        )}
       </main>
     </div>
   );

--- a/client/src/utils/formatters.js
+++ b/client/src/utils/formatters.js
@@ -1,0 +1,53 @@
+// /client/src/utils/formatters.js
+
+/**
+ * Formats a number into USD currency string
+ * Adds "+" sign for positive values
+ */
+export const formatCurrency = (value) => {
+  if (value == null) return "Open";
+  const sign = value > 0 ? "+" : "";
+  return (
+    sign +
+    value.toLocaleString("en-US", {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 2,
+    })
+  );
+};
+
+/**
+ * Formats a numeric price to 2 decimal places
+ * e.g. 19500.2500 → "19,500.25"
+ */
+export const formatPrice = (value) => {
+  if (value == null) return "—";
+  return Number(value).toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+};
+
+/**
+ * Formats quantity as a whole number integer
+ * e.g. 1.0000 → "1"
+ */
+export const formatQuantity = (value) => {
+  if (value == null) return "—";
+  return parseInt(value, 10).toString();
+};
+
+/**
+ * Formats an ISO datetime string into a readable short format
+ * e.g. "Jan 5, 02:30 PM"
+ */
+export const formatDateTime = (iso) => {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};

--- a/server/src/modules/trades/controllers/trades.controller.js
+++ b/server/src/modules/trades/controllers/trades.controller.js
@@ -99,6 +99,36 @@ const TradesController = {
       return sendError(res, err);
     }
   },
+
+  /**
+   * PATCH /api/trades/:id/close
+   * Close an open trade
+   */
+  closeTrade: async (req, res) => {
+    const { id } = req.params;
+
+    logger.info("Close trade request received", { tradeId: id });
+
+    try {
+      const trade = await TradesService.closeTrade(id, req.userId, req.body);
+
+      const response = sendSuccess(res, {
+        message: "Trade closed",
+        data: trade,
+      });
+
+      logger.info("Close trade response sent", { tradeId: id });
+
+      return response;
+    } catch (err) {
+      logger.error("Close trade failed in controller", {
+        tradeId: id,
+        error: err.message,
+      });
+
+      return sendError(res, err);
+    }
+  },
 };
 
 module.exports = TradesController;

--- a/server/src/modules/trades/repositories/trades.repository.js
+++ b/server/src/modules/trades/repositories/trades.repository.js
@@ -99,6 +99,54 @@ const TradesRepository = {
       handleDbError(error);
     }
   },
+
+  /**
+   * Find a single trade by tradeId
+   *
+   * @param {string} tradeId - The trade's UUID
+   * @returns {Object|null} The trade row or null if not found
+   */
+  findById: async (tradeId) => {
+    logger.debug("Finding trade by ID", { tradeId });
+
+    const { rows } = await query(`SELECT * FROM trades WHERE trade_id = $1`, [
+      tradeId,
+    ]);
+
+    return rows[0] || null;
+  },
+
+  /**
+   * Close an open trade
+   *
+   * @param {string} tradeId - The trade's UUID
+   * @param {number} exitPrice - The exit price
+   * @param {string} exitTime - The exit timestamp
+   * @param {Date} closedAt - Server-derived close timestamp
+   * @returns {Object} The updated trade row
+   */
+  closeTrade: async (tradeId, exitPrice, exitTime, closedAt) => {
+    logger.debug("Closing trade in database", { tradeId });
+
+    try {
+      const { rows } = await query(
+        `UPDATE trades
+        SET exit_price   = $1,
+            exit_time    = $2,
+            trade_status = 'closed',
+            closed_at    = $3
+        WHERE trade_id = $4
+        RETURNING *`,
+        [exitPrice, exitTime, closedAt, tradeId],
+      );
+
+      logger.debug("Trade closed in database", { tradeId });
+
+      return rows[0];
+    } catch (error) {
+      handleDbError(error);
+    }
+  },
 };
 
 module.exports = TradesRepository;

--- a/server/src/modules/trades/routes/trades.route.js
+++ b/server/src/modules/trades/routes/trades.route.js
@@ -15,5 +15,6 @@ router.use(authMiddleware);
 
 router.get("/", TradesController.getAll);
 router.post("/", TradesController.create);
+router.patch("/:id/close", TradesController.closeTrade);
 
 module.exports = router;

--- a/server/src/modules/trades/services/trades.service.js
+++ b/server/src/modules/trades/services/trades.service.js
@@ -1,6 +1,9 @@
 // /server/src/modules/trades/services/trades.service.js
 
-const { validateTrade } = require("../validation/trades.validation");
+const {
+  validateTrade,
+  validateCloseTrade,
+} = require("../validation/trades.validation");
 const TradesRepository = require("../repositories/trades.repository");
 const createLogger = require("../../../utils/logger");
 
@@ -33,18 +36,17 @@ const TradesService = {
    */
   getAllTrades: async (userId) => {
     logger.debug("Fetching all trades", { userId });
-  
+
     const trades = await TradesRepository.findAll(userId);
-  
+
     const safeTrades = Array.isArray(trades) ? trades : [];
-  
+
     logger.debug("Trades retrieved from repository", {
       count: safeTrades.length,
     });
-  
+
     return safeTrades;
   },
-  
 
   /**
    * Create a new trade
@@ -56,56 +58,149 @@ const TradesService = {
    */
   createTrade: async (tradeInput, userId) => {
     logger.debug("Starting trade creation");
-  
+
     // =========================
     // Validation
     // =========================
     const validationError = validateTrade(tradeInput);
-  
+
     if (validationError) {
       logger.warn("Trade validation failed", {
         error: validationError.message,
         field: validationError.field,
       });
-  
+
       const err = new Error(validationError.message);
       err.code = "VALIDATION_ERROR";
       err.status = 400;
       err.field = validationError.field;
-  
+
       throw err;
     }
-  
+
     logger.debug("Trade validation passed");
-  
+
     // =========================
     // Data Normalization
     // =========================
     const newTrade = {
       userId,
-      symbol:     tradeInput.symbol,
-      tradeType:  tradeInput.type,
+      symbol: tradeInput.symbol,
+      tradeType: tradeInput.type,
       entryPrice: Number(tradeInput.entryPrice),
-      exitPrice:  tradeInput.exitPrice  ? Number(tradeInput.exitPrice)  : null,
-      entryTime:  tradeInput.entryTime  || null,
-      exitTime:   tradeInput.exitTime   || null,
-      quantity:   Number(tradeInput.quantity),
-      notes:      tradeInput.notes      || null,
-      strategy:   tradeInput.strategy   || null,
+      exitPrice: tradeInput.exitPrice ? Number(tradeInput.exitPrice) : null,
+      entryTime: tradeInput.entryTime || null,
+      exitTime: tradeInput.exitTime || null,
+      quantity: Number(tradeInput.quantity),
+      notes: tradeInput.notes || null,
+      strategy: tradeInput.strategy || null,
     };
-  
+
     // =========================
     // Persist
     // =========================
     logger.debug("Persisting trade", { userId });
-  
+
     const savedTrade = await TradesRepository.create(newTrade);
-  
+
     logger.info("Trade successfully created", {
       tradeId: savedTrade.trade_id,
     });
-  
+
     return savedTrade;
+  },
+
+  /**
+   * Close an open trade
+   *
+   * FLOW:
+   * Controller → Service → Validation → Ownership Check → Status Check → Repository
+   *
+   * BUSINESS RULES:
+   * - Trade must exist (404)
+   * - Trade must belong to the requesting user (403)
+   * - Trade must be open (400)
+   * - exitPrice and exitTime are required and valid
+   *
+   * @param {string} tradeId   - UUID of the trade to close
+   * @param {string} userId    - UUID of the authenticated user
+   * @param {Object} payload   - { exitPrice, exitTime }
+   * @returns {Object} The updated trade
+   */
+  closeTrade: async (tradeId, userId, payload) => {
+    logger.debug("Starting close trade", { tradeId, userId });
+
+    // =========================
+    // Validation
+    // =========================
+    const validationError = validateCloseTrade(payload);
+
+    if (validationError) {
+      logger.warn("Close trade validation failed", {
+        error: validationError.message,
+        field: validationError.field,
+      });
+
+      const err = new Error(validationError.message);
+      err.code = "VALIDATION_ERROR";
+      err.status = 400;
+      err.field = validationError.field;
+      throw err;
+    }
+
+    // =========================
+    // Existence check
+    // =========================
+    const trade = await TradesRepository.findById(tradeId);
+
+    if (!trade) {
+      logger.warn("Close trade failed — trade not found", { tradeId });
+
+      const err = new Error("Trade not found");
+      err.code = "NOT_FOUND";
+      err.status = 404;
+      throw err;
+    }
+
+    // =========================
+    // Ownership check
+    // =========================
+    if (trade.user_id !== userId) {
+      logger.warn("Close trade failed — forbidden", { tradeId, userId });
+
+      const err = new Error("You do not have permission to close this trade");
+      err.code = "FORBIDDEN";
+      err.status = 403;
+      throw err;
+    }
+
+    // =========================
+    // Status check
+    // =========================
+    if (trade.trade_status === "closed") {
+      logger.warn("Close trade failed — trade already closed", { tradeId });
+
+      const err = new Error("Trade is already closed");
+      err.code = "TRADE_ALREADY_CLOSED";
+      err.status = 400;
+      throw err;
+    }
+
+    // =========================
+    // Persist
+    // =========================
+    const closedAt = new Date();
+
+    const updatedTrade = await TradesRepository.closeTrade(
+      tradeId,
+      Number(payload.exitPrice),
+      payload.exitTime,
+      closedAt,
+    );
+
+    logger.info("Trade closed successfully", { tradeId });
+
+    return updatedTrade;
   },
 };
 

--- a/server/src/modules/trades/validation/trades.validation.js
+++ b/server/src/modules/trades/validation/trades.validation.js
@@ -121,7 +121,49 @@ function validateTrade(trade) {
   return null;
 }
 
+/**
+ * Validates the payload for closing a trade
+ *
+ * @param {Object} payload - { exitPrice, exitTime }
+ * @returns {null | { message: string, field?: string }}
+ */
+function validateCloseTrade(payload) {
+  if (!payload || typeof payload !== "object") {
+    return createValidationError("Invalid payload");
+  }
+
+  const { exitPrice, exitTime } = payload;
+
+  // =========================
+  // Required fields
+  // =========================
+  if (exitPrice == null) {
+    return createValidationError("Exit price is required", "exitPrice");
+  }
+
+  if (!exitTime) {
+    return createValidationError("Exit time is required", "exitTime");
+  }
+
+  // =========================
+  // Numeric validation
+  // =========================
+  if (isNaN(Number(exitPrice))) {
+    return createValidationError("Exit price must be a number", "exitPrice");
+  }
+
+  if (Number(exitPrice) <= 0) {
+    return createValidationError(
+      "Exit price must be greater than 0",
+      "exitPrice",
+    );
+  }
+
+  return null;
+}
+
 module.exports = {
   validateTrade,
+  validateCloseTrade,
   TRADE_TYPES,
 };

--- a/server/tests/api/trades.test.js
+++ b/server/tests/api/trades.test.js
@@ -2,7 +2,12 @@
 
 const request = require("supertest");
 const app = require("../../src/app");
-const { validTrade, invalidTrade } = require("../fixtures/trades");
+const {
+  validTrade,
+  invalidTrade,
+  openTrade,
+  createOpenTrade,
+} = require("../fixtures/trades");
 const { getAuthCookie, clearDatabase } = require("../fixtures/auth");
 
 /**
@@ -335,5 +340,115 @@ describe("Trade API", () => {
     expect(res.body.error).toBeDefined();
     expect(res.body.error.message).toMatch(/exit time/i);
     expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  // =========================
+  // Test Case 1.10
+  // Close an open trade
+  // =========================
+  /**
+   * Validates that a PATCH to /close updates the trade
+   * to closed status with exit data populated.
+   *
+   * EXPECTED:
+   * - HTTP 200
+   * - trade_status is "closed"
+   * - exit_price and closed_at are set
+   */
+  it("closes an open trade", async () => {
+    const trade = await createOpenTrade(cookie);
+
+    const res = await request(app)
+      .patch(`/api/trades/${trade.trade_id}/close`)
+      .set("Cookie", cookie)
+      .send({
+        exitPrice: 150,
+        exitTime: "2024-01-10T11:00:00",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.trade_status).toBe("closed");
+    expect(res.body.data.exit_price).toBeDefined();
+    expect(res.body.data.closed_at).toBeDefined();
+  });
+
+  // =========================
+  // Test Case 1.11
+  // Cannot close an already closed trade
+  // =========================
+  /**
+   * Validates that closing an already-closed trade
+   * returns a 400 with a descriptive error.
+   *
+   * EXPECTED:
+   * - HTTP 400
+   * - error code TRADE_ALREADY_CLOSED
+   */
+  it("returns 400 when closing an already closed trade", async () => {
+    const trade = await createOpenTrade(cookie);
+
+    // Close it once
+    await request(app)
+      .patch(`/api/trades/${trade.trade_id}/close`)
+      .set("Cookie", cookie)
+      .send({ exitPrice: 150, exitTime: "2024-01-10T11:00:00" });
+
+    // Close it again
+    const res = await request(app)
+      .patch(`/api/trades/${trade.trade_id}/close`)
+      .set("Cookie", cookie)
+      .send({ exitPrice: 155, exitTime: "2024-01-10T12:00:00" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("TRADE_ALREADY_CLOSED");
+  });
+
+  // =========================
+  // Test Case 1.12
+  // Cannot close another user's trade
+  // =========================
+  /**
+   * Validates that closing a trade belonging to a different
+   * user returns 403.
+   *
+   * EXPECTED:
+   * - HTTP 403
+   * - error code FORBIDDEN
+   */
+  it("returns 403 when closing another user's trade", async () => {
+    const trade = await createOpenTrade(cookie);
+
+    // Create a second authenticated user
+    const otherCookie = await getAuthCookie();
+
+    const res = await request(app)
+      .patch(`/api/trades/${trade.trade_id}/close`)
+      .set("Cookie", otherCookie)
+      .send({ exitPrice: 150, exitTime: "2024-01-10T11:00:00" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  // =========================
+  // Test Case 1.13
+  // Cannot close a non-existent trade
+  // =========================
+  /**
+   * Validates that closing a trade that does not exist
+   * returns 404.
+   *
+   * EXPECTED:
+   * - HTTP 404
+   * - error code NOT_FOUND
+   */
+  it("returns 404 when closing a non-existent trade", async () => {
+    const res = await request(app)
+      .patch("/api/trades/00000000-0000-0000-0000-000000000000/close")
+      .set("Cookie", cookie)
+      .send({ exitPrice: 150, exitTime: "2024-01-10T11:00:00" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
   });
 });

--- a/server/tests/fixtures/trades.js
+++ b/server/tests/fixtures/trades.js
@@ -1,5 +1,8 @@
 // /server/tests/fixtures/trades.js
 
+const request = require("supertest");
+const app = require("../../src/app");
+
 function validTrade(overrides = {}) {
   return {
     symbol: "AAPL",
@@ -21,4 +24,24 @@ function invalidTrade(overrides = {}) {
   };
 }
 
-module.exports = { validTrade, invalidTrade };
+// Helper to create an open trade and return it
+function openTrade(overrides = {}) {
+  return {
+    symbol: "AAPL",
+    type: "BUY",
+    entryPrice: 100,
+    quantity: 1,
+    entryTime: "2026-04-21T09:00:00Z",
+    ...overrides,
+  };
+}
+
+const createOpenTrade = async (cookie) => {
+  const res = await request(app)
+    .post("/api/trades")
+    .set("Cookie", cookie)
+    .send(openTrade());
+  return res.body.data;
+};
+
+module.exports = { validTrade, invalidTrade, openTrade, createOpenTrade };


### PR DESCRIPTION
closes #52 

## Summary

Implements User Story 1 — Close an Open Trade. Adds a `PATCH /api/trades/:id/close`
endpoint that accepts `exitPrice` and `exitTime`, updates `trade_status` to `closed`,
and sets `closed_at`. The frontend displays a Close button on open trade rows that
opens a confirmation modal.

## Changes

### Backend
- `trades.repository.js` — added `findById` and `closeTrade`
- `trades.validation.js` — added `validateCloseTrade`
- `trades.service.js` — added `closeTrade` with ownership, existence, and status checks
- `trades.controller.js` — added `closeTrade` handler
- `trades.route.js` — added `PATCH /:id/close` route

### Tests
- `fixtures/trades.js` — added `openTrade` and `createOpenTrade`
- `trades.test.js` — added tests 1.10 – 1.13

### Frontend
- `utils/formatters.js` — extracted `formatCurrency`, `formatPrice`, `formatQuantity`, `formatDateTime` from `TradeEntry`
- `components/CloseTradeModal.jsx` — new modal component
- `TradeEntry.jsx` — added modal state, `handleCloseTrade`, Close button on open rows, amber P&L for open trades

## Test Coverage

| Test | Description |
|------|-------------|
| 1.10 | Closes an open trade |
| 1.11 | Returns 400 when closing an already closed trade |
| 1.12 | Returns 403 when closing another user's trade |
| 1.13 | Returns 404 when closing a non-existent trade |

**Total: 29 → 33 passing tests**