### PR TITLE
feat: add delete trade endpoint (DELETE /api/trades/:id)

### DIFF
--- a/client/src/components/DeleteConfirmModal.jsx
+++ b/client/src/components/DeleteConfirmModal.jsx
@@ -1,0 +1,56 @@
+// /client/src/components/DeleteConfirmModal.jsx
+
+/**
+ * Modal to confirm trade deletion
+ *
+ * @param {Object}   trade        - The trade being deleted
+ * @param {Function} onConfirm    - Called with tradeId on confirmation
+ * @param {Function} onCancel     - Called when user dismisses the modal
+ * @param {boolean}  isSubmitting - Disables confirm button during request
+ * @param {string}   error        - Error message to display inside modal
+ */
+export default function DeleteConfirmModal({ trade, onConfirm, onCancel, isSubmitting, error }) {
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50">
+      <div className="bg-zinc-900 border border-zinc-700 rounded-2xl p-6 w-full max-w-md space-y-5">
+
+        <div>
+          <h2 className="text-lg font-semibold text-white">Delete Trade</h2>
+          <p className="text-sm text-zinc-400 mt-1">
+            This action cannot be undone.
+          </p>
+        </div>
+
+        <div className="bg-zinc-800 border border-zinc-700 rounded-lg px-4 py-3 text-sm text-zinc-300 space-y-1">
+          <p><span className="text-zinc-500">Symbol</span> · {trade.symbol}</p>
+          <p><span className="text-zinc-500">Type</span> · {trade.trade_type}</p>
+          <p><span className="text-zinc-500">Status</span> · {trade.trade_status}</p>
+        </div>
+
+        {error && (
+          <p className="text-sm text-red-400 bg-red-950 border border-red-800 rounded-lg px-4 py-2.5">
+            {error}
+          </p>
+        )}
+
+        <div className="flex justify-end gap-3 pt-1">
+          <button
+            onClick={onCancel}
+            disabled={isSubmitting}
+            className="text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-500 rounded-lg px-4 py-2 transition"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => onConfirm(trade.trade_id)}
+            disabled={isSubmitting}
+            className="bg-red-600 hover:bg-red-500 disabled:opacity-50 text-white font-semibold rounded-lg px-5 py-2 text-sm transition"
+          >
+            {isSubmitting ? "Deleting..." : "Delete"}
+          </button>
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/TradeEntry.jsx
+++ b/client/src/pages/TradeEntry.jsx
@@ -15,6 +15,7 @@ import {
 } from "../utils/validation";
 import { formatCurrency, formatPrice, formatQuantity, formatDateTime } from "../utils/formatters";
 import CloseTradeModal from "../components/CloseTradeModal";
+import DeleteConfirmModal from "../components/DeleteConfirmModal";
 
 /**
  * =========================================================
@@ -86,9 +87,13 @@ export default function TradeEntry() {
    */
   const [trades, setTrades] = useState([]);
 
-  const [closingTrade, setClosingTrade]       = useState(null);  // trade being closed
+  const [closingTrade, setClosingTrade]       = useState(null); 
   const [closeError, setCloseError]           = useState("");
   const [closeSubmitting, setCloseSubmitting] = useState(false);
+
+  const [deletingTrade, setDeletingTrade]     = useState(null);
+  const [deleteError, setDeleteError]         = useState("");
+  const [deleteSubmitting, setDeleteSubmitting] = useState(false);
 
   // =========================================================
   // LOGOUT
@@ -276,6 +281,38 @@ export default function TradeEntry() {
       setCloseError("Network error. Please try again.");
     } finally {
       setCloseSubmitting(false);
+    }
+  };
+
+  /**
+   * Submit delete trade request to backend
+   * Removes trade row from list on success
+   */
+  const handleDeleteTrade = async (tradeId) => {
+    setDeleteError("");
+    setDeleteSubmitting(true);
+
+    try {
+      const res = await fetch(`${API_URL}/api/trades/${tradeId}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+
+      const data = await res.json();
+
+      if (!res.ok || data.status !== "success") {
+        setDeleteError(data.error?.message || "Failed to delete trade");
+        return;
+      }
+
+      // Remove row without re-fetch
+      setTrades((prev) => prev.filter((t) => t.trade_id !== tradeId));
+      setDeletingTrade(null);
+    } catch (err) {
+      console.error("Delete trade error:", err);
+      setDeleteError("Network error. Please try again.");
+    } finally {
+      setDeleteSubmitting(false);
     }
   };
 
@@ -567,7 +604,7 @@ export default function TradeEntry() {
                       {isOpen ? "Open" : formatCurrency(pnl)}
                     </span>
 
-                    <div className="flex justify-end">
+                    <div className="flex justify-end gap-2">
                       {isOpen && (
                         <button
                           onClick={() => { setCloseError(""); setClosingTrade(t); }}
@@ -576,6 +613,13 @@ export default function TradeEntry() {
                           Close
                         </button>
                       )}
+                      <button
+                        onClick={() => { setDeleteError(""); setDeletingTrade(t); }}
+                        className="text-xs text-zinc-400 hover:text-red-400 border border-zinc-700 hover:border-red-500 rounded-md px-3 py-1 transition"
+                      >
+                        Delete
+                      </button>
+
                     </div>
                   </div>
                 );
@@ -591,6 +635,16 @@ export default function TradeEntry() {
             onCancel={() => { setClosingTrade(null); setCloseError(""); }}
             isSubmitting={closeSubmitting}
             error={closeError}
+          />
+        )}
+        
+        {deletingTrade && (
+          <DeleteConfirmModal
+            trade={deletingTrade}
+            onConfirm={handleDeleteTrade}
+            onCancel={() => { setDeletingTrade(null); setDeleteError(""); }}
+            isSubmitting={deleteSubmitting}
+            error={deleteError}
           />
         )}
       </main>

--- a/server/src/modules/trades/controllers/trades.controller.js
+++ b/server/src/modules/trades/controllers/trades.controller.js
@@ -129,6 +129,35 @@ const TradesController = {
       return sendError(res, err);
     }
   },
+
+  /**
+   * DELETE /api/trades/:id
+   * Delete a trade
+   */
+  deleteTrade: async (req, res) => {
+    const { id } = req.params;
+
+    logger.info("Delete trade request received", { tradeId: id });
+
+    try {
+      await TradesService.deleteTrade(id, req.userId);
+
+      const response = sendSuccess(res, {
+        message: "Trade deleted",
+      });
+
+      logger.info("Delete trade response sent", { tradeId: id });
+
+      return response;
+    } catch (err) {
+      logger.error("Delete trade failed in controller", {
+        tradeId: id,
+        error: err.message,
+      });
+
+      return sendError(res, err);
+    }
+  },
 };
 
 module.exports = TradesController;

--- a/server/src/modules/trades/repositories/trades.repository.js
+++ b/server/src/modules/trades/repositories/trades.repository.js
@@ -147,6 +147,24 @@ const TradesRepository = {
       handleDbError(error);
     }
   },
+
+  /**
+   * Delete a trade by ID
+   *
+   * @param {string} tradeId - The trade's UUID
+   * @returns {void}
+   */
+  deleteTrade: async (tradeId) => {
+    logger.debug("Deleting trade from database", { tradeId });
+
+    try {
+      await query(`DELETE FROM trades WHERE trade_id = $1`, [tradeId]);
+
+      logger.debug("Trade deleted from database", { tradeId });
+    } catch (error) {
+      handleDbError(error);
+    }
+  },
 };
 
 module.exports = TradesRepository;

--- a/server/src/modules/trades/routes/trades.route.js
+++ b/server/src/modules/trades/routes/trades.route.js
@@ -16,5 +16,6 @@ router.use(authMiddleware);
 router.get("/", TradesController.getAll);
 router.post("/", TradesController.create);
 router.patch("/:id/close", TradesController.closeTrade);
+router.delete("/:id", TradesController.deleteTrade);
 
 module.exports = router;

--- a/server/src/modules/trades/services/trades.service.js
+++ b/server/src/modules/trades/services/trades.service.js
@@ -202,6 +202,57 @@ const TradesService = {
 
     return updatedTrade;
   },
+
+  /**
+   * Delete a trade
+   *
+   * FLOW:
+   * Controller → Service → Existence Check → Ownership Check → Repository
+   *
+   * BUSINESS RULES:
+   * - Trade must exist (404)
+   * - Trade must belong to the requesting user (403)
+   *
+   * @param {string} tradeId - UUID of the trade to delete
+   * @param {string} userId  - UUID of the authenticated user
+   * @returns {void}
+   */
+  deleteTrade: async (tradeId, userId) => {
+    logger.debug("Starting delete trade", { tradeId, userId });
+
+    // =========================
+    // Existence check
+    // =========================
+    const trade = await TradesRepository.findById(tradeId);
+
+    if (!trade) {
+      logger.warn("Delete trade failed — trade not found", { tradeId });
+
+      const err = new Error("Trade not found");
+      err.code = "NOT_FOUND";
+      err.status = 404;
+      throw err;
+    }
+
+    // =========================
+    // Ownership check
+    // =========================
+    if (trade.user_id !== userId) {
+      logger.warn("Delete trade failed — forbidden", { tradeId, userId });
+
+      const err = new Error("You do not have permission to delete this trade");
+      err.code = "FORBIDDEN";
+      err.status = 403;
+      throw err;
+    }
+
+    // =========================
+    // Persist
+    // =========================
+    await TradesRepository.deleteTrade(tradeId);
+
+    logger.info("Trade deleted successfully", { tradeId });
+  },
 };
 
 module.exports = TradesService;

--- a/server/tests/api/trades.test.js
+++ b/server/tests/api/trades.test.js
@@ -451,4 +451,78 @@ describe("Trade API", () => {
     expect(res.status).toBe(404);
     expect(res.body.error.code).toBe("NOT_FOUND");
   });
+
+  // =========================
+  // Test Case 1.14
+  // Delete a trade
+  // =========================
+  /**
+   * Validates that a trade is successfully deleted.
+   *
+   * EXPECTED:
+   * - HTTP 200
+   * - Trade no longer returned in findAll
+   */
+  it("deletes a trade", async () => {
+    const trade = await createOpenTrade(cookie);
+
+    const res = await request(app)
+      .delete(`/api/trades/${trade.trade_id}`)
+      .set("Cookie", cookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe("Trade deleted");
+
+    // Confirm it's gone
+    const listRes = await request(app).get("/api/trades").set("Cookie", cookie);
+
+    const ids = listRes.body.data.map((t) => t.trade_id);
+    expect(ids).not.toContain(trade.trade_id);
+  });
+
+  // =========================
+  // Test Case 1.15
+  // Cannot delete another user's trade
+  // =========================
+  /**
+   * Validates that deleting a trade belonging to a different
+   * user returns 403.
+   *
+   * EXPECTED:
+   * - HTTP 403
+   * - error code FORBIDDEN
+   */
+  it("returns 403 when deleting another user's trade", async () => {
+    const trade = await createOpenTrade(cookie);
+
+    const otherCookie = await getAuthCookie();
+
+    const res = await request(app)
+      .delete(`/api/trades/${trade.trade_id}`)
+      .set("Cookie", otherCookie);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  // =========================
+  // Test Case 1.16
+  // Cannot delete a non-existent trade
+  // =========================
+  /**
+   * Validates that deleting a trade that does not exist
+   * returns 404.
+   *
+   * EXPECTED:
+   * - HTTP 404
+   * - error code NOT_FOUND
+   */
+  it("returns 404 when deleting a non-existent trade", async () => {
+    const res = await request(app)
+      .delete("/api/trades/00000000-0000-0000-0000-000000000000")
+      .set("Cookie", cookie);
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
 });


### PR DESCRIPTION
close #53 

## Summary

Implements User Story 2 — Delete a Trade. Adds a `DELETE /api/trades/:id` endpoint
that removes a trade from the database. The frontend displays a Delete button on every
trade row and prompts the user to confirm before deletion. The row is removed from the
list without a full page reload.

## Changes

### Backend
- `trades.repository.js` — added `deleteTrade`
- `trades.service.js` — added `deleteTrade` with existence and ownership checks
- `trades.controller.js` — added `deleteTrade` handler
- `trades.route.js` — added `DELETE /:id` route

### Tests
- `trades.test.js` — added tests 1.14 – 1.16

### Frontend
- `components/DeleteConfirmModal.jsx` — new modal component
- `TradeEntry.jsx` — added delete state, `handleDeleteTrade`, Delete button on all rows

## Test Coverage

| Test | Description |
|------|-------------|
| 1.14 | Deletes a trade and confirms it is removed |
| 1.15 | Returns 403 when deleting another user's trade |
| 1.16 | Returns 404 when deleting a non-existent trade |

**Total: 33 → 36 passing tests**