### PR TITLE
feat: add edit trade endpoint (PUT /api/trades/:id)

### DIFF
--- a/client/src/components/EditTradeModal.jsx
+++ b/client/src/components/EditTradeModal.jsx
@@ -1,0 +1,221 @@
+// /client/src/components/EditTradeModal.jsx
+
+import { useState } from "react";
+import {
+  validatePositiveNumber,
+  validatePositiveInteger,
+  validateExitAfterEntry,
+  validateExitFields,
+} from "../utils/validation";
+
+/**
+ * Modal to edit an existing trade
+ *
+ * Pre-populates form with existing trade data.
+ * Recalculates trade_status on the backend based on exitPrice.
+ *
+ * @param {Object}   trade        - The trade being edited
+ * @param {Function} onConfirm    - Called with (tradeId, payload) on submission
+ * @param {Function} onCancel     - Called when user dismisses the modal
+ * @param {boolean}  isSubmitting - Disables confirm button during request
+ * @param {string}   error        - Error message to display inside modal
+ */
+export default function EditTradeModal({ trade, onConfirm, onCancel, isSubmitting, error }) {
+
+  // Pre-populate from existing trade
+  const [form, setForm] = useState({
+    symbol:     trade.symbol       || "",
+    type:       trade.trade_type   || "BUY",
+    entryPrice: trade.entry_price  || "",
+    exitPrice:  trade.exit_price   || "",
+    entryTime:  trade.entry_time   ? trade.entry_time.slice(0, 16) : "",
+    exitTime:   trade.exit_time    ? trade.exit_time.slice(0, 16)  : "",
+    quantity:   trade.quantity     || "",
+    notes:      trade.notes        || "",
+    strategy:   trade.strategy     || "",
+  });
+
+  const [formError, setFormError] = useState("");
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = () => {
+    setFormError("");
+
+    // =========================
+    // Frontend Validation
+    // =========================
+    const entryPriceError     = validatePositiveNumber(form.entryPrice, "Entry price");
+    const quantityError       = validatePositiveInteger(form.quantity, "Quantity");
+    const exitPriceError      = form.exitPrice ? validatePositiveNumber(form.exitPrice, "Exit price") : null;
+    const exitFieldsError     = validateExitFields(form.exitPrice, form.exitTime);
+    const exitAfterEntryError = validateExitAfterEntry(form.entryTime, form.exitTime);
+
+    const validationError = entryPriceError || quantityError || exitPriceError || exitFieldsError || exitAfterEntryError;
+
+    if (validationError) {
+      setFormError(validationError);
+      return;
+    }
+
+    onConfirm(trade.trade_id, {
+      ...form,
+      symbol:     form.symbol.toUpperCase(),
+      type:       form.type.toUpperCase(),
+      entryPrice: Number(form.entryPrice),
+      exitPrice:  form.exitPrice ? Number(form.exitPrice) : null,
+      quantity:   Number(form.quantity),
+    });
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50">
+      <div className="bg-zinc-900 border border-zinc-700 rounded-2xl p-6 w-full max-w-lg space-y-5 max-h-[90vh] overflow-y-auto">
+
+        <div>
+          <h2 className="text-lg font-semibold text-white">Edit Trade</h2>
+          <p className="text-sm text-zinc-400 mt-1">
+            {trade.symbol} · {trade.trade_type}
+          </p>
+        </div>
+
+        <div className="space-y-4">
+
+          {/* ROW 1: Symbol, Type, Quantity */}
+          <div className="grid grid-cols-3 gap-3">
+            <div>
+              <label className="block text-xs text-zinc-400 uppercase tracking-wider mb-1.5">Symbol</label>
+              <input
+                name="symbol"
+                value={form.symbol}
+                onChange={handleChange}
+                className="w-full bg-zinc-800 border border-zinc-700 text-white rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent transition"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-zinc-400 uppercase tracking-wider mb-1.5">Type</label>
+              <select
+                name="type"
+                value={form.type}
+                onChange={handleChange}
+                className="w-full bg-zinc-800 border border-zinc-700 text-white rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent transition"
+              >
+                <option value="BUY">Buy</option>
+                <option value="SELL">Sell</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-xs text-zinc-400 uppercase tracking-wider mb-1.5">Lot Size</label>
+              <input
+                name="quantity"
+                value={form.quantity}
+                onChange={handleChange}
+                className="w-full bg-zinc-800 border border-zinc-700 text-white rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent transition"
+              />
+            </div>
+          </div>
+
+          {/* ROW 2: Entry Price, Exit Price */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs text-zinc-400 uppercase tracking-wider mb-1.5">Entry Price</label>
+              <input
+                name="entryPrice"
+                value={form.entryPrice}
+                onChange={handleChange}
+                className="w-full bg-zinc-800 border border-zinc-700 text-white rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent transition"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-zinc-400 uppercase tracking-wider mb-1.5">
+                Exit Price <span className="text-zinc-600 normal-case">(optional)</span>
+              </label>
+              <input
+                name="exitPrice"
+                value={form.exitPrice}
+                onChange={handleChange}
+                className="w-full bg-zinc-800 border border-zinc-700 text-white rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent transition"
+              />
+            </div>
+          </div>
+
+          {/* ROW 3: Entry Time, Exit Time */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs text-zinc-400 uppercase tracking-wider mb-1.5">Entry Time</label>
+              <input
+                type="datetime-local"
+                name="entryTime"
+                value={form.entryTime}
+                onChange={handleChange}
+                className="w-full bg-zinc-800 border border-zinc-700 text-white rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent transition"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-zinc-400 uppercase tracking-wider mb-1.5">
+                Exit Time <span className="text-zinc-600 normal-case">(optional)</span>
+              </label>
+              <input
+                type="datetime-local"
+                name="exitTime"
+                value={form.exitTime}
+                onChange={handleChange}
+                className="w-full bg-zinc-800 border border-zinc-700 text-white rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent transition"
+              />
+            </div>
+          </div>
+
+          {/* ROW 4: Strategy, Notes */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs text-zinc-400 uppercase tracking-wider mb-1.5">Strategy</label>
+              <input
+                name="strategy"
+                value={form.strategy}
+                onChange={handleChange}
+                className="w-full bg-zinc-800 border border-zinc-700 text-white rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent transition"
+              />
+            </div>
+            <div>
+              <label className="block text-xs text-zinc-400 uppercase tracking-wider mb-1.5">Notes</label>
+              <textarea
+                name="notes"
+                value={form.notes}
+                onChange={handleChange}
+                rows={1}
+                className="w-full bg-zinc-800 border border-zinc-700 text-white rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent transition resize-none"
+              />
+            </div>
+          </div>
+        </div>
+
+        {(formError || error) && (
+          <p className="text-sm text-red-400 bg-red-950 border border-red-800 rounded-lg px-4 py-2.5">
+            {formError || error}
+          </p>
+        )}
+
+        <div className="flex justify-end gap-3 pt-1">
+          <button
+            onClick={onCancel}
+            disabled={isSubmitting}
+            className="text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-500 rounded-lg px-4 py-2 transition"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={isSubmitting}
+            className="bg-emerald-500 hover:bg-emerald-400 disabled:opacity-50 text-zinc-950 font-semibold rounded-lg px-5 py-2 text-sm transition"
+          >
+            {isSubmitting ? "Saving..." : "Save Changes"}
+          </button>
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/TradeEntry.jsx
+++ b/client/src/pages/TradeEntry.jsx
@@ -16,6 +16,7 @@ import {
 import { formatCurrency, formatPrice, formatQuantity, formatDateTime } from "../utils/formatters";
 import CloseTradeModal from "../components/CloseTradeModal";
 import DeleteConfirmModal from "../components/DeleteConfirmModal";
+import EditTradeModal from "../components/EditTradeModal";
 
 /**
  * =========================================================
@@ -94,6 +95,10 @@ export default function TradeEntry() {
   const [deletingTrade, setDeletingTrade]     = useState(null);
   const [deleteError, setDeleteError]         = useState("");
   const [deleteSubmitting, setDeleteSubmitting] = useState(false);
+
+  const [editingTrade, setEditingTrade]       = useState(null);
+  const [editError, setEditError]             = useState("");
+  const [editSubmitting, setEditSubmitting]   = useState(false);
 
   // =========================================================
   // LOGOUT
@@ -313,6 +318,43 @@ export default function TradeEntry() {
       setDeleteError("Network error. Please try again.");
     } finally {
       setDeleteSubmitting(false);
+    }
+  };
+
+  /**
+   * Submit edit trade request to backend
+   * Updates trade row in place on success
+   */
+  const handleEditTrade = async (tradeId, payload) => {
+    setEditError("");
+    setEditSubmitting(true);
+
+    try {
+      const res = await fetch(`${API_URL}/api/trades/${tradeId}`, {
+        method: "PUT",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok || data.status !== "success") {
+        setEditError(data.error?.message || "Failed to update trade");
+        return;
+      }
+
+      // Update the row in place — no re-fetch needed
+      setTrades((prev) =>
+        prev.map((t) => (t.trade_id === tradeId ? data.data : t))
+      );
+
+      setEditingTrade(null);
+    } catch (err) {
+      console.error("Edit trade error:", err);
+      setEditError("Network error. Please try again.");
+    } finally {
+      setEditSubmitting(false);
     }
   };
 
@@ -557,7 +599,7 @@ export default function TradeEntry() {
           <div className="bg-zinc-900 border border-zinc-800 rounded-2xl overflow-hidden">
 
             {/* TABLE HEADER */}
-            <div className="grid grid-cols-9 gap-4 px-6 py-3 border-b border-zinc-800 text-xs text-zinc-500 uppercase tracking-wider">
+            <div className="grid grid-cols-10 gap-4 px-6 py-3 border-b border-zinc-800 text-xs text-zinc-500 uppercase tracking-wider">
               <span>Symbol</span>
               <span>Type</span>
               <span>Entry Time</span>
@@ -582,7 +624,7 @@ export default function TradeEntry() {
                 return (
                   <div
                     key={t.trade_id || `${t.symbol}-${t.entry_time}`}
-                    className="grid grid-cols-9 gap-4 px-6 py-4 border-b border-zinc-800 last:border-0 hover:bg-zinc-800/50 transition text-sm items-center"
+                    className="grid grid-cols-10 gap-4 px-6 py-4 border-b border-zinc-800 last:border-0 hover:bg-zinc-800/50 transition text-sm items-center"
                   >
                     <span className="font-medium text-white">{t.symbol}</span>
 
@@ -604,7 +646,7 @@ export default function TradeEntry() {
                       {isOpen ? "Open" : formatCurrency(pnl)}
                     </span>
 
-                    <div className="flex justify-end gap-2">
+                    <div className="col-span-2 flex justify-end gap-2">
                       {isOpen && (
                         <button
                           onClick={() => { setCloseError(""); setClosingTrade(t); }}
@@ -613,6 +655,12 @@ export default function TradeEntry() {
                           Close
                         </button>
                       )}
+                      <button
+                        onClick={() => { setEditError(""); setEditingTrade(t); }}
+                        className="text-xs text-zinc-400 hover:text-blue-400 border border-zinc-700 hover:border-blue-500 rounded-md px-3 py-1 transition"
+                      >
+                        Edit
+                      </button>
                       <button
                         onClick={() => { setDeleteError(""); setDeletingTrade(t); }}
                         className="text-xs text-zinc-400 hover:text-red-400 border border-zinc-700 hover:border-red-500 rounded-md px-3 py-1 transition"
@@ -645,6 +693,16 @@ export default function TradeEntry() {
             onCancel={() => { setDeletingTrade(null); setDeleteError(""); }}
             isSubmitting={deleteSubmitting}
             error={deleteError}
+          />
+        )}
+
+        {editingTrade && (
+          <EditTradeModal
+            trade={editingTrade}
+            onConfirm={handleEditTrade}
+            onCancel={() => { setEditingTrade(null); setEditError(""); }}
+            isSubmitting={editSubmitting}
+            error={editError}
           />
         )}
       </main>

--- a/server/src/modules/trades/controllers/trades.controller.js
+++ b/server/src/modules/trades/controllers/trades.controller.js
@@ -158,6 +158,36 @@ const TradesController = {
       return sendError(res, err);
     }
   },
+
+  /**
+   * PUT /api/trades/:id
+   * Edit a trade
+   */
+  editTrade: async (req, res) => {
+    const { id } = req.params;
+
+    logger.info("Edit trade request received", { tradeId: id });
+
+    try {
+      const trade = await TradesService.editTrade(id, req.userId, req.body);
+
+      const response = sendSuccess(res, {
+        message: "Trade updated",
+        data: trade,
+      });
+
+      logger.info("Edit trade response sent", { tradeId: id });
+
+      return response;
+    } catch (err) {
+      logger.error("Edit trade failed in controller", {
+        tradeId: id,
+        error: err.message,
+      });
+
+      return sendError(res, err);
+    }
+  },
 };
 
 module.exports = TradesController;

--- a/server/src/modules/trades/repositories/trades.repository.js
+++ b/server/src/modules/trades/repositories/trades.repository.js
@@ -165,6 +165,73 @@ const TradesRepository = {
       handleDbError(error);
     }
   },
+
+  /**
+   * Update a trade by ID
+   *
+   * @param {string} tradeId    - The trade's UUID
+   * @param {Object} fields     - { symbol, tradeType, entryPrice, exitPrice,
+   *                               entryTime, exitTime, quantity, notes,
+   *                               strategy, tradeStatus, closedAt }
+   * @returns {Object} The updated trade row
+   */
+  updateTrade: async (
+    tradeId,
+    {
+      symbol,
+      tradeType,
+      entryPrice,
+      exitPrice,
+      entryTime,
+      exitTime,
+      quantity,
+      notes,
+      strategy,
+      tradeStatus,
+      closedAt,
+    },
+  ) => {
+    logger.debug("Updating trade in database", { tradeId });
+
+    try {
+      const { rows } = await query(
+        `UPDATE trades
+        SET symbol       = $1,
+            trade_type   = $2,
+            entry_price  = $3,
+            exit_price   = $4,
+            entry_time   = $5,
+            exit_time    = $6,
+            quantity     = $7,
+            notes        = $8,
+            strategy     = $9,
+            trade_status = $10,
+            closed_at    = $11
+        WHERE trade_id = $12
+        RETURNING *`,
+        [
+          symbol,
+          tradeType,
+          entryPrice,
+          exitPrice || null,
+          entryTime || null,
+          exitTime || null,
+          quantity,
+          notes || null,
+          strategy || null,
+          tradeStatus,
+          closedAt,
+          tradeId,
+        ],
+      );
+
+      logger.debug("Trade updated in database", { tradeId });
+
+      return rows[0];
+    } catch (error) {
+      handleDbError(error);
+    }
+  },
 };
 
 module.exports = TradesRepository;

--- a/server/src/modules/trades/routes/trades.route.js
+++ b/server/src/modules/trades/routes/trades.route.js
@@ -17,5 +17,6 @@ router.get("/", TradesController.getAll);
 router.post("/", TradesController.create);
 router.patch("/:id/close", TradesController.closeTrade);
 router.delete("/:id", TradesController.deleteTrade);
+router.put("/:id", TradesController.editTrade);
 
 module.exports = router;

--- a/server/src/modules/trades/services/trades.service.js
+++ b/server/src/modules/trades/services/trades.service.js
@@ -3,6 +3,7 @@
 const {
   validateTrade,
   validateCloseTrade,
+  validateEditTrade,
 } = require("../validation/trades.validation");
 const TradesRepository = require("../repositories/trades.repository");
 const createLogger = require("../../../utils/logger");
@@ -252,6 +253,107 @@ const TradesService = {
     await TradesRepository.deleteTrade(tradeId);
 
     logger.info("Trade deleted successfully", { tradeId });
+  },
+
+  /**
+   * Edit a trade
+   *
+   * FLOW:
+   * Controller → Service → Validation → Existence Check → Ownership Check → Normalization → Repository
+   *
+   * BUSINESS RULES:
+   * - Trade must exist (404)
+   * - Trade must belong to the requesting user (403)
+   * - All existing validation rules apply
+   * - trade_status and closed_at are recalculated from exitPrice
+   *
+   * @param {string} tradeId    - UUID of the trade to edit
+   * @param {string} userId     - UUID of the authenticated user
+   * @param {Object} tradeInput - Raw edit payload from request
+   * @returns {Object} The updated trade
+   */
+  editTrade: async (tradeId, userId, tradeInput) => {
+    logger.debug("Starting edit trade", { tradeId, userId });
+
+    // =========================
+    // Validation
+    // =========================
+    const validationError = validateEditTrade(tradeInput);
+
+    if (validationError) {
+      logger.warn("Edit trade validation failed", {
+        error: validationError.message,
+        field: validationError.field,
+      });
+
+      const err = new Error(validationError.message);
+      err.code = "VALIDATION_ERROR";
+      err.status = 400;
+      err.field = validationError.field;
+      throw err;
+    }
+
+    // =========================
+    // Existence check
+    // =========================
+    const trade = await TradesRepository.findById(tradeId);
+
+    if (!trade) {
+      logger.warn("Edit trade failed — trade not found", { tradeId });
+
+      const err = new Error("Trade not found");
+      err.code = "NOT_FOUND";
+      err.status = 404;
+      throw err;
+    }
+
+    // =========================
+    // Ownership check
+    // =========================
+    if (trade.user_id !== userId) {
+      logger.warn("Edit trade failed — forbidden", { tradeId, userId });
+
+      const err = new Error("You do not have permission to edit this trade");
+      err.code = "FORBIDDEN";
+      err.status = 403;
+      throw err;
+    }
+
+    // =========================
+    // Normalization
+    // Recalculate trade_status and closed_at from exitPrice
+    // =========================
+    const exitPrice = tradeInput.exitPrice
+      ? Number(tradeInput.exitPrice)
+      : null;
+    const tradeStatus = exitPrice ? "closed" : "open";
+    const closedAt = exitPrice ? new Date() : null;
+
+    const updatedFields = {
+      symbol: tradeInput.symbol,
+      tradeType: tradeInput.type,
+      entryPrice: Number(tradeInput.entryPrice),
+      exitPrice,
+      entryTime: tradeInput.entryTime || null,
+      exitTime: tradeInput.exitTime || null,
+      quantity: Number(tradeInput.quantity),
+      notes: tradeInput.notes || null,
+      strategy: tradeInput.strategy || null,
+      tradeStatus,
+      closedAt,
+    };
+
+    // =========================
+    // Persist
+    // =========================
+    const updatedTrade = await TradesRepository.updateTrade(
+      tradeId,
+      updatedFields,
+    );
+
+    logger.info("Trade edited successfully", { tradeId });
+
+    return updatedTrade;
   },
 };
 

--- a/server/src/modules/trades/validation/trades.validation.js
+++ b/server/src/modules/trades/validation/trades.validation.js
@@ -162,8 +162,114 @@ function validateCloseTrade(payload) {
   return null;
 }
 
+/**
+ * Validates the payload for editing a trade
+ *
+ * Mirrors validateTrade but operates on normalized field names
+ * to match the existing trade record shape.
+ *
+ * @param {Object} trade - Incoming edit payload
+ * @returns {null | { message: string, field?: string }}
+ */
+function validateEditTrade(trade) {
+  if (!trade || typeof trade !== "object") {
+    return createValidationError("Invalid payload");
+  }
+
+  const { symbol, type, entryPrice, quantity, exitPrice, exitTime, entryTime } =
+    trade;
+
+  // =========================
+  // Required fields
+  // =========================
+  if (!symbol) {
+    return createValidationError("Symbol is required", "symbol");
+  }
+
+  if (!type) {
+    return createValidationError("Trade type is required", "type");
+  }
+
+  if (entryPrice == null) {
+    return createValidationError("Entry price is required", "entryPrice");
+  }
+
+  if (quantity == null) {
+    return createValidationError("Quantity is required", "quantity");
+  }
+
+  // =========================
+  // Enum validation
+  // =========================
+  if (!Object.values(TRADE_TYPES).includes(type)) {
+    return createValidationError("Invalid trade type", "type");
+  }
+
+  // =========================
+  // Numeric validation (NaN)
+  // =========================
+  if (isNaN(Number(entryPrice))) {
+    return createValidationError("Entry price must be a number", "entryPrice");
+  }
+
+  if (isNaN(Number(quantity))) {
+    return createValidationError("Quantity must be a number", "quantity");
+  }
+
+  if (exitPrice != null && isNaN(Number(exitPrice))) {
+    return createValidationError("Exit price must be a number", "exitPrice");
+  }
+
+  // =========================
+  // Numeric validation (range)
+  // =========================
+  if (Number(entryPrice) <= 0) {
+    return createValidationError(
+      "Entry price must be greater than 0",
+      "entryPrice",
+    );
+  }
+
+  if (Number(quantity) <= 0) {
+    return createValidationError("Quantity must be greater than 0", "quantity");
+  }
+
+  if (exitPrice != null && Number(exitPrice) <= 0) {
+    return createValidationError(
+      "Exit price must be greater than 0",
+      "exitPrice",
+    );
+  }
+
+  // =========================
+  // Exit data consistency
+  // =========================
+  const hasExitPrice = exitPrice != null;
+  const hasExitTime = !!exitTime;
+
+  if ((hasExitPrice || hasExitTime) && !(hasExitPrice && hasExitTime)) {
+    return createValidationError(
+      "Exit price and exit time must both be provided",
+      "exit",
+    );
+  }
+
+  // =========================
+  // Temporal validation
+  // =========================
+  if (entryTime && exitTime && new Date(exitTime) <= new Date(entryTime)) {
+    return createValidationError(
+      "Exit time must be after entry time",
+      "exitTime",
+    );
+  }
+
+  return null;
+}
+
 module.exports = {
   validateTrade,
   validateCloseTrade,
+  validateEditTrade,
   TRADE_TYPES,
 };

--- a/server/tests/api/trades.test.js
+++ b/server/tests/api/trades.test.js
@@ -525,4 +525,159 @@ describe("Trade API", () => {
     expect(res.status).toBe(404);
     expect(res.body.error.code).toBe("NOT_FOUND");
   });
+
+  // =========================
+  // Test Case 1.17
+  // Edit a trade — success
+  // =========================
+  /**
+   * Validates that a trade is successfully updated
+   * with new field values.
+   *
+   * EXPECTED:
+   * - HTTP 200
+   * - Returned trade reflects updated values
+   */
+  it("edits a trade", async () => {
+    const trade = await createOpenTrade(cookie);
+
+    const res = await request(app)
+      .put(`/api/trades/${trade.trade_id}`)
+      .set("Cookie", cookie)
+      .send({
+        symbol: "TSLA",
+        type: "SELL",
+        entryPrice: 200,
+        quantity: 2,
+        entryTime: "2026-04-21T09:00:00Z",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.symbol).toBe("TSLA");
+    expect(res.body.data.trade_type).toBe("SELL");
+    expect(res.body.data.trade_status).toBe("open");
+  });
+
+  // =========================
+  // Test Case 1.18
+  // Edit recalculates trade_status and closed_at
+  // =========================
+  /**
+   * Validates that adding an exitPrice on edit
+   * recalculates trade_status to closed.
+   *
+   * EXPECTED:
+   * - HTTP 200
+   * - trade_status is "closed"
+   * - closed_at is set
+   */
+  it("recalculates trade_status when exitPrice is added on edit", async () => {
+    const trade = await createOpenTrade(cookie);
+
+    const res = await request(app)
+      .put(`/api/trades/${trade.trade_id}`)
+      .set("Cookie", cookie)
+      .send({
+        symbol: "AAPL",
+        type: "BUY",
+        entryPrice: 100,
+        quantity: 1,
+        entryTime: "2026-04-21T09:00:00Z",
+        exitPrice: 150,
+        exitTime: "2026-04-21T10:00:00Z",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.trade_status).toBe("closed");
+    expect(res.body.data.closed_at).toBeDefined();
+  });
+
+  // =========================
+  // Test Case 1.19
+  // Cannot edit another user's trade
+  // =========================
+  /**
+   * Validates that editing a trade belonging to a different
+   * user returns 403.
+   *
+   * EXPECTED:
+   * - HTTP 403
+   * - error code FORBIDDEN
+   */
+  it("returns 403 when editing another user's trade", async () => {
+    const trade = await createOpenTrade(cookie);
+    const otherCookie = await getAuthCookie();
+
+    const res = await request(app)
+      .put(`/api/trades/${trade.trade_id}`)
+      .set("Cookie", otherCookie)
+      .send({
+        symbol: "AAPL",
+        type: "BUY",
+        entryPrice: 100,
+        quantity: 1,
+        entryTime: "2026-04-21T09:00:00Z",
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  // =========================
+  // Test Case 1.20
+  // Cannot edit a non-existent trade
+  // =========================
+  /**
+   * Validates that editing a trade that does not exist
+   * returns 404.
+   *
+   * EXPECTED:
+   * - HTTP 404
+   * - error code NOT_FOUND
+   */
+  it("returns 404 when editing a non-existent trade", async () => {
+    const res = await request(app)
+      .put("/api/trades/00000000-0000-0000-0000-000000000000")
+      .set("Cookie", cookie)
+      .send({
+        symbol: "AAPL",
+        type: "BUY",
+        entryPrice: 100,
+        quantity: 1,
+        entryTime: "2026-04-21T09:00:00Z",
+      });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("NOT_FOUND");
+  });
+
+  // =========================
+  // Test Case 1.21
+  // Edit validation applies
+  // =========================
+  /**
+   * Validates that existing validation rules
+   * are enforced on edit payloads.
+   *
+   * EXPECTED:
+   * - HTTP 400
+   * - error code VALIDATION_ERROR
+   */
+  it("returns 400 when edit payload fails validation", async () => {
+    const trade = await createOpenTrade(cookie);
+
+    const res = await request(app)
+      .put(`/api/trades/${trade.trade_id}`)
+      .set("Cookie", cookie)
+      .send({
+        symbol: "AAPL",
+        type: "BUY",
+        entryPrice: -100,
+        quantity: 1,
+        entryTime: "2026-04-21T09:00:00Z",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
 });


### PR DESCRIPTION
closes #54 

## Summary

Implements User Story 3 — Edit a Trade. Adds a `PUT /api/trades/:id` endpoint
that accepts all editable trade fields and recalculates `trade_status` and
`closed_at` based on the updated `exitPrice`. The frontend displays an Edit
button on every trade row that opens a pre-populated modal. The row is updated
in place without a full page reload.

## Changes

### Backend
- `trades.validation.js` — added `validateEditTrade` (dedicated validator,
  decoupled from create)
- `trades.repository.js` — added `updateTrade`
- `trades.service.js` — added `editTrade` with existence, ownership, and
  validation checks; recalculates `trade_status` and `closed_at`
- `trades.controller.js` — added `editTrade` handler
- `trades.route.js` — added `PUT /:id` route

### Tests
- `trades.test.js` — added tests 1.17 – 1.21

### Frontend
- `components/EditTradeModal.jsx` — new modal component, pre-populated from
  existing trade data with full client-side validation
- `TradeEntry.jsx` — added edit state, `handleEditTrade`, Edit button on all rows

## Test Coverage

| Test | Description |
|------|-------------|
| 1.17 | Edits a trade successfully |
| 1.18 | Recalculates trade_status when exitPrice is added on edit |
| 1.19 | Returns 403 when editing another user's trade |
| 1.20 | Returns 404 when editing a non-existent trade |
| 1.21 | Returns 400 when edit payload fails validation |

**Total: 36 → 41 passing tests**