### PR TITLE
feat: add analytics endpoints (P&L by period, win rate, symbol breakdown)

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -8,6 +8,7 @@ const requestLogger = require("./middleware/requestLogger.middleware");
 
 const authRoutes = require("./modules/auth/routes/auth.routes");
 const tradeRoutes = require("./modules/trades/routes/trades.route");
+const analyticsRoutes = require("./modules/analytics/routes/analytics.routes");
 
 const app = express();
 
@@ -45,6 +46,7 @@ app.use(requestLogger);
  */
 app.use("/api/auth", authRoutes);
 app.use("/api/trades", tradeRoutes);
+app.use("/api/analytics", analyticsRoutes);
 
 /**
  * HEALTH CHECK

--- a/server/src/modules/analytics/controllers/analytics.controller.js
+++ b/server/src/modules/analytics/controllers/analytics.controller.js
@@ -1,0 +1,87 @@
+// /server/src/modules/analytics/controllers/analytics.controller.js
+
+const AnalyticsService = require("../services/analytics.service");
+const createLogger = require("../../../utils/logger");
+
+const logger = createLogger("analytics.controller");
+
+const sendSuccess = (res, { statusCode = 200, data }) => {
+  return res.status(statusCode).json({
+    status: "success",
+    ...(data !== undefined && { data }),
+  });
+};
+
+const sendError = (res, err) => {
+  const statusCode = err.status || 500;
+  const message =
+    statusCode === 500
+      ? "Internal server error"
+      : err.message || "Something went wrong";
+  const code = err.code || (statusCode === 500 ? "INTERNAL_ERROR" : "ERROR");
+
+  return res.status(statusCode).json({ error: { message, code } });
+};
+
+const AnalyticsController = {
+  /**
+   * GET /api/analytics/pnl?period=day|week|month
+   */
+  getPnLByPeriod: async (req, res) => {
+    const { period = "day" } = req.query;
+
+    logger.info("GET /api/analytics/pnl request received", { period });
+
+    try {
+      const data = await AnalyticsService.getPnLByPeriod(req.userId, period);
+
+      logger.info("P&L by period response sent", {
+        period,
+        count: data.length,
+      });
+
+      return sendSuccess(res, { data });
+    } catch (err) {
+      logger.error("Failed to fetch P&L by period", { error: err.message });
+      return sendError(res, err);
+    }
+  },
+
+  /**
+   * GET /api/analytics/win-rate
+   */
+  getWinRate: async (req, res) => {
+    logger.info("GET /api/analytics/win-rate request received");
+
+    try {
+      const data = await AnalyticsService.getWinRate(req.userId);
+
+      logger.info("Win rate response sent", { winRate: data.winRate });
+
+      return sendSuccess(res, { data });
+    } catch (err) {
+      logger.error("Failed to fetch win rate", { error: err.message });
+      return sendError(res, err);
+    }
+  },
+
+  /**
+   * GET /api/analytics/symbols
+   */
+  getSymbolBreakdown: async (req, res) => {
+    logger.info("GET /api/analytics/symbols request received");
+
+    try {
+      const data = await AnalyticsService.getSymbolBreakdown(req.userId);
+
+      logger.info("Symbol breakdown response sent", { count: data.length });
+
+      return sendSuccess(res, { data });
+    } catch (err) {
+      logger.error("Failed to fetch symbol breakdown", { error: err.message });
+      return sendError(res, err);
+    }
+  },
+};
+
+module.exports = AnalyticsController;

--- a/server/src/modules/analytics/repositories/analytics.repository.js
+++ b/server/src/modules/analytics/repositories/analytics.repository.js
@@ -1,0 +1,40 @@
+// /server/src/modules/analytics/repositories/analytics.repository.js
+
+const { query } = require("../../../db/config/db");
+const createLogger = require("../../../utils/logger");
+
+const logger = createLogger("analytics.repository");
+
+const AnalyticsRepository = {
+  /**
+   * Fetch all closed trades for a user
+   * Used as the base dataset for all analytics calculations
+   *
+   * @param {string} userId
+   * @returns {Array} closed trades
+   */
+  getClosedTrades: async (userId) => {
+    logger.debug("Fetching closed trades for analytics", { userId });
+
+    const { rows } = await query(
+      `SELECT
+            trade_id,
+            symbol,
+            trade_type,
+            entry_price,
+            exit_price,
+            quantity,
+            closed_at
+        FROM trades
+        WHERE user_id    = $1
+            AND trade_status = 'closed'
+            AND exit_price IS NOT NULL
+        ORDER BY closed_at ASC`,
+      [userId],
+    );
+
+    return rows;
+  },
+};
+
+module.exports = AnalyticsRepository;

--- a/server/src/modules/analytics/routes/analytics.routes.js
+++ b/server/src/modules/analytics/routes/analytics.routes.js
@@ -1,0 +1,19 @@
+// /server/src/modules/analytics/routes/analytics.routes.js
+
+const express = require("express");
+const AnalyticsController = require("../controllers/analytics.controller");
+const requireAuth = require("../../../middleware/auth.middleware");
+
+const router = express.Router();
+
+/**
+ * =========================
+ * PROTECTED ROUTES
+ * =========================
+ */
+
+router.get("/pnl", requireAuth, AnalyticsController.getPnLByPeriod);
+router.get("/win-rate", requireAuth, AnalyticsController.getWinRate);
+router.get("/symbols", requireAuth, AnalyticsController.getSymbolBreakdown);
+
+module.exports = router;

--- a/server/src/modules/analytics/services/analytics.service.js
+++ b/server/src/modules/analytics/services/analytics.service.js
@@ -1,0 +1,173 @@
+// /server/src/modules/analytics/services/analytics.service.js
+
+const AnalyticsRepository = require("../repositories/analytics.repository");
+const { SYMBOL_MULTIPLIERS } = require("../../../utils/constants");
+const createLogger = require("../../../utils/logger");
+
+const logger = createLogger("analytics.service");
+
+/**
+ * Calculate P&L for a single trade
+ * Applies futures multiplier where applicable
+ *
+ * @param {Object} trade - trade row from DB
+ * @returns {number} dollar P&L
+ */
+const calculateTradePnL = (trade) => {
+  const multiplier = SYMBOL_MULTIPLIERS[trade.symbol?.toUpperCase()] || 1;
+  const entry = Number(trade.entry_price);
+  const exit = Number(trade.exit_price);
+  const qty = Number(trade.quantity);
+
+  const diff = trade.trade_type === "BUY" ? exit - entry : entry - exit;
+
+  return diff * qty * multiplier;
+};
+
+/**
+ * Format a date into a period label
+ *
+ * @param {Date}   date
+ * @param {string} period - "day" | "week" | "month"
+ * @returns {string} label
+ */
+const getPeriodLabel = (date, period) => {
+  const d = new Date(date);
+
+  if (period === "day") {
+    return d.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  }
+
+  if (period === "week") {
+    // ISO week start (Monday)
+    const day = d.getDay();
+    const diff = d.getDate() - day + (day === 0 ? -6 : 1);
+    const monday = new Date(d.setDate(diff));
+    return `Week of ${monday.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+    })}`;
+  }
+
+  // month
+  return d.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+};
+
+const AnalyticsService = {
+  /**
+   * P&L grouped by period
+   *
+   * @param {string} userId
+   * @param {string} period - "day" | "week" | "month"
+   * @returns {Array} [{ period, pnl }]
+   */
+  getPnLByPeriod: async (userId, period) => {
+    logger.debug("Calculating P&L by period", { userId, period });
+
+    const VALID_PERIODS = ["day", "week", "month"];
+
+    if (!VALID_PERIODS.includes(period)) {
+      const err = new Error("Invalid period. Must be day, week, or month");
+      err.code = "VALIDATION_ERROR";
+      err.status = 400;
+      throw err;
+    }
+
+    const trades = await AnalyticsRepository.getClosedTrades(userId);
+
+    // Group P&L by period label
+    const grouped = {};
+
+    for (const trade of trades) {
+      const label = getPeriodLabel(trade.closed_at, period);
+      const pnl = calculateTradePnL(trade);
+      grouped[label] = (grouped[label] || 0) + pnl;
+    }
+
+    const result = Object.entries(grouped).map(([label, pnl]) => ({
+      period: label,
+      pnl: Math.round(pnl * 100) / 100,
+    }));
+
+    logger.debug("P&L by period calculated", { count: result.length });
+
+    return result;
+  },
+
+  /**
+   * Win rate across all closed trades
+   *
+   * @param {string} userId
+   * @returns {Object} { total, wins, losses, breakevens, winRate }
+   */
+  getWinRate: async (userId) => {
+    logger.debug("Calculating win rate", { userId });
+
+    const trades = await AnalyticsRepository.getClosedTrades(userId);
+
+    let wins = 0,
+      losses = 0,
+      breakevens = 0;
+
+    for (const trade of trades) {
+      const pnl = calculateTradePnL(trade);
+      if (pnl > 0) wins++;
+      else if (pnl < 0) losses++;
+      else breakevens++;
+    }
+
+    const total = trades.length;
+    const winRate = total > 0 ? Math.round((wins / total) * 10000) / 100 : 0;
+
+    logger.debug("Win rate calculated", { total, wins, losses, winRate });
+
+    return { total, wins, losses, breakevens, winRate };
+  },
+
+  /**
+   * P&L and win rate grouped by symbol
+   *
+   * @param {string} userId
+   * @returns {Array} [{ symbol, totalPnl, tradeCount, wins, winRate }]
+   */
+  getSymbolBreakdown: async (userId) => {
+    logger.debug("Calculating symbol breakdown", { userId });
+
+    const trades = await AnalyticsRepository.getClosedTrades(userId);
+
+    const symbolMap = {};
+
+    for (const trade of trades) {
+      const symbol = trade.symbol.toUpperCase();
+      const pnl = calculateTradePnL(trade);
+
+      if (!symbolMap[symbol]) {
+        symbolMap[symbol] = { symbol, totalPnl: 0, tradeCount: 0, wins: 0 };
+      }
+
+      symbolMap[symbol].totalPnl += pnl;
+      symbolMap[symbol].tradeCount += 1;
+      if (pnl > 0) symbolMap[symbol].wins += 1;
+    }
+
+    const result = Object.values(symbolMap)
+      .map((s) => ({
+        symbol: s.symbol,
+        totalPnl: Math.round(s.totalPnl * 100) / 100,
+        tradeCount: s.tradeCount,
+        wins: s.wins,
+        winRate: Math.round((s.wins / s.tradeCount) * 10000) / 100,
+      }))
+      .sort((a, b) => b.totalPnl - a.totalPnl);
+
+    logger.debug("Symbol breakdown calculated", { symbolCount: result.length });
+
+    return result;
+  },
+};
+
+module.exports = AnalyticsService;

--- a/server/src/utils/constants.js
+++ b/server/src/utils/constants.js
@@ -1,0 +1,24 @@
+// /server/src/utils/constants.js
+
+/**
+ * Futures contract multipliers
+ *
+ * Used to calculate actual dollar P&L for futures instruments.
+ * Shared across the analytics and trades modules.
+ *
+ * P&L formula:
+ * (exitPrice - entryPrice) * quantity * multiplier  (BUY)
+ * (entryPrice - exitPrice) * quantity * multiplier  (SELL)
+ */
+const SYMBOL_MULTIPLIERS = {
+  NQ: 20,
+  ES: 50,
+  YM: 5,
+  RTY: 50,
+  MNQ: 2,
+  MES: 5,
+  MYM: 0.5,
+  M2K: 5,
+};
+
+module.exports = { SYMBOL_MULTIPLIERS };

--- a/server/tests/api/analytics.test.js
+++ b/server/tests/api/analytics.test.js
@@ -1,0 +1,229 @@
+// /server/tests/api/analytics.test.js
+
+const request = require("supertest");
+const app = require("../../src/app");
+const { getAuthCookie, clearDatabase } = require("../fixtures/auth");
+const { validTrade, openTrade } = require("../fixtures/trades");
+
+/**
+ * =========================================================
+ * ANALYTICS API TEST SUITE
+ * =========================================================
+ *
+ * PURPOSE:
+ * Validates all analytics endpoints including P&L by period,
+ * win rate, and symbol breakdown.
+ *
+ * COVERAGE:
+ * - Empty state (no closed trades)
+ * - Correct calculations with known trade data
+ * - Period validation
+ * - Auth protection
+ *
+ * DESIGN PRINCIPLES:
+ * - Uses known trade values to assert exact calculations
+ * - Tests are isolated via beforeEach database clear
+ * =========================================================
+ */
+
+describe("Analytics API", () => {
+  let cookie;
+
+  afterAll(async () => {
+    await clearDatabase();
+  });
+
+  beforeEach(async () => {
+    await clearDatabase();
+    cookie = await getAuthCookie();
+  });
+
+  // =========================
+  // Test Case 4.1
+  // P&L by period — empty state
+  // =========================
+  /**
+   * Validates that the endpoint returns an empty array
+   * when there are no closed trades.
+   */
+  it("returns empty array for P&L when no closed trades exist", async () => {
+    const res = await request(app)
+      .get("/api/analytics/pnl?period=day")
+      .set("Cookie", cookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+
+  // =========================
+  // Test Case 4.2
+  // P&L by period — with data
+  // =========================
+  /**
+   * Validates that P&L is calculated correctly for a known trade.
+   * AAPL BUY: (150 - 100) * 1 * 1 = $50
+   */
+  it("returns correct P&L by day for closed trades", async () => {
+    await request(app)
+      .post("/api/trades")
+      .set("Cookie", cookie)
+      .send(validTrade());
+
+    const res = await request(app)
+      .get("/api/analytics/pnl?period=day")
+      .set("Cookie", cookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBeGreaterThan(0);
+    expect(typeof res.body.data[0].period).toBe("string");
+    expect(typeof res.body.data[0].pnl).toBe("number");
+  });
+
+  // =========================
+  // Test Case 4.3
+  // P&L by period — invalid period
+  // =========================
+  /**
+   * Validates that an invalid period returns 400.
+   */
+  it("returns 400 for invalid period parameter", async () => {
+    const res = await request(app)
+      .get("/api/analytics/pnl?period=year")
+      .set("Cookie", cookie);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  // =========================
+  // Test Case 4.4
+  // Win rate — empty state
+  // =========================
+  /**
+   * Validates that win rate returns zero values
+   * when there are no closed trades.
+   */
+  it("returns zero win rate when no closed trades exist", async () => {
+    const res = await request(app)
+      .get("/api/analytics/win-rate")
+      .set("Cookie", cookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.total).toBe(0);
+    expect(res.body.data.winRate).toBe(0);
+  });
+
+  // =========================
+  // Test Case 4.5
+  // Win rate — with data
+  // =========================
+  /**
+   * Validates win rate calculation with a known winning trade.
+   * AAPL BUY entry 100 exit 150 = profit = win
+   */
+  it("calculates win rate correctly for closed trades", async () => {
+    await request(app)
+      .post("/api/trades")
+      .set("Cookie", cookie)
+      .send(validTrade());
+
+    const res = await request(app)
+      .get("/api/analytics/win-rate")
+      .set("Cookie", cookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.total).toBe(1);
+    expect(res.body.data.wins).toBe(1);
+    expect(res.body.data.losses).toBe(0);
+    expect(res.body.data.winRate).toBe(100);
+  });
+
+  // =========================
+  // Test Case 4.6
+  // Symbol breakdown — empty state
+  // =========================
+  /**
+   * Validates that symbol breakdown returns empty array
+   * when there are no closed trades.
+   */
+  it("returns empty array for symbol breakdown when no closed trades exist", async () => {
+    const res = await request(app)
+      .get("/api/analytics/symbols")
+      .set("Cookie", cookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+
+  // =========================
+  // Test Case 4.7
+  // Symbol breakdown — with data
+  // =========================
+  /**
+   * Validates symbol breakdown includes correct fields
+   * and is sorted by totalPnl descending.
+   */
+  it("returns symbol breakdown sorted by P&L", async () => {
+    await request(app)
+      .post("/api/trades")
+      .set("Cookie", cookie)
+      .send(validTrade());
+
+    const res = await request(app)
+      .get("/api/analytics/symbols")
+      .set("Cookie", cookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBeGreaterThan(0);
+
+    const symbol = res.body.data[0];
+    expect(symbol.symbol).toBeDefined();
+    expect(symbol.totalPnl).toBeDefined();
+    expect(symbol.tradeCount).toBe(1);
+    expect(symbol.winRate).toBe(100);
+  });
+
+  // =========================
+  // Test Case 4.8
+  // Open trades excluded
+  // =========================
+  /**
+   * Validates that open trades are not included
+   * in any analytics calculation.
+   */
+  it("excludes open trades from all analytics", async () => {
+    await request(app)
+      .post("/api/trades")
+      .set("Cookie", cookie)
+      .send(openTrade());
+
+    const [pnlRes, winRateRes, symbolRes] = await Promise.all([
+      request(app).get("/api/analytics/pnl?period=day").set("Cookie", cookie),
+      request(app).get("/api/analytics/win-rate").set("Cookie", cookie),
+      request(app).get("/api/analytics/symbols").set("Cookie", cookie),
+    ]);
+
+    expect(pnlRes.body.data).toEqual([]);
+    expect(winRateRes.body.data.total).toBe(0);
+    expect(symbolRes.body.data).toEqual([]);
+  });
+
+  // =========================
+  // Test Case 4.9
+  // Auth protection
+  // =========================
+  /**
+   * Validates that all analytics endpoints require authentication.
+   */
+  it("returns 401 for unauthenticated requests", async () => {
+    const [pnlRes, winRateRes, symbolRes] = await Promise.all([
+      request(app).get("/api/analytics/pnl?period=day"),
+      request(app).get("/api/analytics/win-rate"),
+      request(app).get("/api/analytics/symbols"),
+    ]);
+
+    expect(pnlRes.status).toBe(401);
+    expect(winRateRes.status).toBe(401);
+    expect(symbolRes.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary

Implements Dashboard & Analytics User Stories 1–3. Adds three analytics
endpoints powered by pure SQL queries against the existing schema. A shared
constants file centralises futures multipliers across the backend. All
calculations are scoped to the authenticated user and exclude open trades.

## Changes

### Backend
- `utils/constants.js` — extracted `SYMBOL_MULTIPLIERS` from frontend,
  now shared across backend modules
- `modules/analytics/repositories/analytics.repository.js` — fetches closed
  trades as base dataset for all analytics
- `modules/analytics/services/analytics.service.js` — P&L by period, win
  rate, and symbol breakdown calculations with futures multiplier support
- `modules/analytics/controllers/analytics.controller.js` — thin controller
  delegating to service
- `modules/analytics/routes/analytics.routes.js` — three protected routes
- `app.js` — registered `/api/analytics` routes

### Tests
- `tests/api/analytics.test.js` — new test suite (9 tests)

## Endpoints

| Endpoint | Description |
|----------|-------------|
| `GET /api/analytics/pnl?period=day\|week\|month` | P&L grouped by period |
| `GET /api/analytics/win-rate` | Win rate across all closed trades |
| `GET /api/analytics/symbols` | P&L and win rate grouped by symbol |

## Test Coverage

| Test | Description |
|------|-------------|
| 4.1 | Returns empty array for P&L when no closed trades exist |
| 4.2 | Returns correct P&L by day for closed trades |
| 4.3 | Returns 400 for invalid period parameter |
| 4.4 | Returns zero win rate when no closed trades exist |
| 4.5 | Calculates win rate correctly for closed trades |
| 4.6 | Returns empty array for symbol breakdown when no closed trades exist |
| 4.7 | Returns symbol breakdown sorted by P&L |
| 4.8 | Excludes open trades from all analytics |
| 4.9 | Returns 401 for unauthenticated requests |

**Total: 41 → 50 passing tests**