### PR TITLE
feat: add emotional state tracking to trade entries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,11 +101,11 @@ jobs:
 
           echo "All required environment variables are present"
         env:
-          DB_HOST:        localhost
-          DB_PORT:        "5432"
-          DB_NAME:        tradetrack
-          DB_USER:        postgres
-          DB_PASSWORD:    ${{ secrets.DB_PASSWORD }}
+          DB_HOST: localhost
+          DB_PORT: "5432"
+          DB_NAME: tradetrack
+          DB_USER: postgres
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
           SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
 
       # --------------------------------------------------------
@@ -129,6 +129,7 @@ jobs:
         run: |
           psql -h localhost -U postgres -d tradetrack_test -f server/src/db/migrations/001_initial_schema.sql
           psql -h localhost -U postgres -d tradetrack_test -f server/src/db/migrations/002_add_entry_exit_time_to_trades.sql
+          psql -h localhost -U postgres -d tradetrack_test -f server/src/db/migrations/003_add_emotions_to_trades.sql
 
       # --------------------------------------------------------
       # Run the Jest test suite.

--- a/client/src/components/EditTradeModal.jsx
+++ b/client/src/components/EditTradeModal.jsx
@@ -7,6 +7,8 @@ import {
   validateExitAfterEntry,
   validateExitFields,
 } from "../utils/validation";
+import { toLocalDateTimeInput, toUTCString } from "../utils/formatters";
+import JournalSection from "./JournalSection";
 
 /**
  * Modal to edit an existing trade
@@ -28,11 +30,14 @@ export default function EditTradeModal({ trade, onConfirm, onCancel, isSubmittin
     type:       trade.trade_type   || "BUY",
     entryPrice: trade.entry_price  || "",
     exitPrice:  trade.exit_price   || "",
-    entryTime:  trade.entry_time   ? trade.entry_time.slice(0, 16) : "",
-    exitTime:   trade.exit_time    ? trade.exit_time.slice(0, 16)  : "",
+    entryTime:  toLocalDateTimeInput(trade.entry_time),
+    exitTime:   toLocalDateTimeInput(trade.exit_time),
     quantity:   trade.quantity     || "",
     notes:      trade.notes        || "",
     strategy:   trade.strategy     || "",
+    emotionBefore: trade.emotion_before || "",
+    emotionDuring: trade.emotion_during || "",
+    emotionAfter:  trade.emotion_after  || "",
   });
 
   const [formError, setFormError] = useState("");
@@ -40,6 +45,10 @@ export default function EditTradeModal({ trade, onConfirm, onCancel, isSubmittin
   const handleChange = (e) => {
     const { name, value } = e.target;
     setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleEmotionChange = (field, value) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
   };
 
   const handleSubmit = () => {
@@ -68,6 +77,11 @@ export default function EditTradeModal({ trade, onConfirm, onCancel, isSubmittin
       entryPrice: Number(form.entryPrice),
       exitPrice:  form.exitPrice ? Number(form.exitPrice) : null,
       quantity:   Number(form.quantity),
+      entryTime:     toUTCString(form.entryTime),
+      exitTime:      toUTCString(form.exitTime),
+      emotionBefore: form.emotionBefore || null,
+      emotionDuring: form.emotionDuring || null,
+      emotionAfter:  form.emotionAfter  || null,
     });
   };
 
@@ -190,6 +204,15 @@ export default function EditTradeModal({ trade, onConfirm, onCancel, isSubmittin
               />
             </div>
           </div>
+
+          {/* JOURNAL */}
+          <JournalSection
+            emotionBefore={form.emotionBefore}
+            emotionDuring={form.emotionDuring}
+            emotionAfter={form.emotionAfter}
+            onChange={handleEmotionChange}
+            defaultOpen={!!(trade.emotion_before || trade.emotion_during || trade.emotion_after)}
+          />
         </div>
 
         {(formError || error) && (

--- a/client/src/components/JournalSection.jsx
+++ b/client/src/components/JournalSection.jsx
@@ -1,0 +1,109 @@
+// /client/src/components/JournalSection.jsx
+
+import { useState } from "react";
+
+/**
+ * Emotion options with emoji representations
+ */
+const EMOTIONS = [
+  { value: "Calm",      emoji: "😌" },
+  { value: "Confident", emoji: "💪" },
+  { value: "Focused",   emoji: "🎯" },
+  { value: "Excited",   emoji: "😄" },
+  { value: "Neutral",   emoji: "😐" },
+  { value: "Anxious",   emoji: "😰" },
+  { value: "Nervous",   emoji: "😬" },
+  { value: "Fearful",   emoji: "😨" },
+  { value: "Greedy",    emoji: "🤑" },
+  { value: "Impatient", emoji: "⏰" },
+  { value: "FOMO",      emoji: "😱" },
+  { value: "Revenge",   emoji: "😤" },
+];
+
+/**
+ * Single emotion picker row
+ */
+function EmotionPicker({ label, value, onChange }) {
+  return (
+    <div>
+      <p className="text-xs text-zinc-400 uppercase tracking-wider mb-2">
+        {label}
+      </p>
+      <div className="flex flex-wrap gap-2">
+        {EMOTIONS.map((e) => (
+          <button
+            key={e.value}
+            type="button"
+            onClick={() => onChange(value === e.value ? "" : e.value)}
+            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs border transition ${
+              value === e.value
+                ? "bg-emerald-500 border-emerald-500 text-zinc-950 font-semibold"
+                : "bg-zinc-800 border-zinc-700 text-zinc-300 hover:border-zinc-500"
+            }`}
+          >
+            <span>{e.emoji}</span>
+            <span>{e.value}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Collapsible journal section for emotional state tracking
+ *
+ * @param {string}   emotionBefore - Selected emotion before trade
+ * @param {string}   emotionDuring - Selected emotion during trade
+ * @param {string}   emotionAfter  - Selected emotion after trade
+ * @param {Function} onChange      - Called with (field, value) on change
+ * @param {boolean}  defaultOpen   - Whether section starts expanded
+ */
+export default function JournalSection({
+  emotionBefore,
+  emotionDuring,
+  emotionAfter,
+  onChange,
+  defaultOpen = false,
+}) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+
+  return (
+    <div className="border border-zinc-700 rounded-lg overflow-hidden">
+
+      {/* Toggle header */}
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        className="w-full flex items-center justify-between px-4 py-3 bg-zinc-800 hover:bg-zinc-700 transition text-sm text-zinc-300 font-medium"
+      >
+        <span>Journal</span>
+        <span className="text-zinc-500 text-xs">
+          {isOpen ? "▲ Hide" : "▼ Show"}
+        </span>
+      </button>
+
+      {/* Content */}
+      {isOpen && (
+        <div className="px-4 py-4 space-y-5 bg-zinc-900">
+          <EmotionPicker
+            label="Before Trade"
+            value={emotionBefore}
+            onChange={(val) => onChange("emotionBefore", val)}
+          />
+          <EmotionPicker
+            label="During Trade"
+            value={emotionDuring}
+            onChange={(val) => onChange("emotionDuring", val)}
+          />
+          <EmotionPicker
+            label="After Trade"
+            value={emotionAfter}
+            onChange={(val) => onChange("emotionAfter", val)}
+          />
+        </div>
+      )}
+
+    </div>
+  );
+}

--- a/client/src/pages/TradeEntry.jsx
+++ b/client/src/pages/TradeEntry.jsx
@@ -13,10 +13,11 @@ import {
   validateExitAfterEntry,
   validateExitFields
 } from "../utils/validation";
-import { formatCurrency, formatPrice, formatQuantity, formatDateTime } from "../utils/formatters";
+import { formatCurrency, formatPrice, formatQuantity, formatDateTime, toUTCString } from "../utils/formatters";
 import CloseTradeModal from "../components/CloseTradeModal";
 import DeleteConfirmModal from "../components/DeleteConfirmModal";
 import EditTradeModal from "../components/EditTradeModal";
+import JournalSection from "../components/JournalSection";
 
 /**
  * =========================================================
@@ -79,7 +80,10 @@ export default function TradeEntry() {
     entryTime: "",
     exitTime: "",
     notes: "",
-    strategy: ""
+    strategy: "",
+    emotionBefore: "",
+    emotionDuring: "",
+    emotionAfter:  "",
   });
 
   const [formError, setFormError] = useState("");
@@ -171,6 +175,10 @@ export default function TradeEntry() {
     }));
   };
 
+  const handleEmotionChange = (field, value) => {
+    setTrade((prev) => ({ ...prev, [field]: value }));
+  };
+
   /**
    * Submit trade to backend
    * Includes validation + safe state update
@@ -205,7 +213,12 @@ export default function TradeEntry() {
       type: trade.type.toUpperCase(),
       entryPrice: Number(trade.entryPrice),
       exitPrice: trade.exitPrice ? Number(trade.exitPrice) : null,
-      quantity: Number(trade.quantity)
+      quantity: Number(trade.quantity),
+      entryTime:     toUTCString(trade.entryTime),
+      exitTime:      toUTCString(trade.exitTime),
+      emotionBefore: trade.emotionBefore || null,
+      emotionDuring: trade.emotionDuring || null,
+      emotionAfter:  trade.emotionAfter  || null,
     };
 
     try {
@@ -244,7 +257,10 @@ export default function TradeEntry() {
         entryTime: "",
         exitTime: "",
         notes: "",
-        strategy: ""
+        strategy: "",
+        emotionBefore: "",
+        emotionDuring: "",
+        emotionAfter:  "",
       });
 
     } catch (err) {
@@ -576,6 +592,14 @@ export default function TradeEntry() {
                 </div>
               </div>
 
+              {/* JOURNAL SECTION */}
+              <JournalSection
+                emotionBefore={trade.emotionBefore}
+                emotionDuring={trade.emotionDuring}
+                emotionAfter={trade.emotionAfter}
+                onChange={handleEmotionChange}
+              />
+
               {/* VALIDATION ERROR */}
               {formError && (
                 <p className="text-sm text-red-400 bg-red-950 border border-red-800 rounded-lg px-4 py-2.5">
@@ -627,6 +651,9 @@ export default function TradeEntry() {
                 trades.filter(Boolean).map((t) => {
                   const pnl = calculatePnL(t);
                   const isOpen = t.exit_price == null;
+
+                  console.log("entry_time raw:", t.entry_time);
+                  console.log("formatted:", formatDateTime(t.entry_time));
 
                   return (
                     <div
@@ -721,6 +748,14 @@ export default function TradeEntry() {
                         <span className="text-zinc-500">Qty </span>
                         <span className="text-zinc-300">{formatQuantity(t.quantity)}</span>
                       </div>
+
+                      {(t.emotion_before || t.emotion_during || t.emotion_after) && (
+                        <div className="flex flex-wrap gap-2 text-xs text-zinc-400 pt-1">
+                          {t.emotion_before && <span>Before: {t.emotion_before}</span>}
+                          {t.emotion_during && <span>During: {t.emotion_during}</span>}
+                          {t.emotion_after  && <span>After: {t.emotion_after}</span>}
+                        </div>
+                      )}
 
                       {/* Actions */}
                       <div className="flex gap-2 pt-1">

--- a/client/src/utils/formatters.js
+++ b/client/src/utils/formatters.js
@@ -51,3 +51,24 @@ export const formatDateTime = (iso) => {
     minute: "2-digit",
   });
 };
+
+/**
+ * Converts a UTC ISO string to a local datetime-local input value
+ * e.g. "2026-04-21T13:00:00.000Z" → "2026-04-21T09:00" (for UTC-4)
+ */
+export const toLocalDateTimeInput = (iso) => {
+  if (!iso) return "";
+  const date = new Date(iso);
+  const offset = date.getTimezoneOffset() * 60000;
+  const local = new Date(date.getTime() - offset);
+  return local.toISOString().slice(0, 16);
+};
+
+/**
+ * Converts a datetime-local input value to a UTC ISO string
+ * e.g. "2026-05-21T14:10" (local) → "2026-05-21T18:10:00.000Z" (UTC)
+ */
+export const toUTCString = (localDatetime) => {
+  if (!localDatetime) return null;
+  return new Date(localDatetime).toISOString();
+};

--- a/server/src/db/migrations/003_add_emotions_to_trades.sql
+++ b/server/src/db/migrations/003_add_emotions_to_trades.sql
@@ -1,0 +1,10 @@
+-- /server/src/db/migrations/003_add_emotions_to_trades.sql
+-- Adds emotional state tracking columns to the trades table.
+-- Traders can record how they felt before, during, and after each trade
+-- to help identify patterns between emotional state and performance.
+-- All three columns are nullable — existing trades are unaffected.
+
+ALTER TABLE trades
+  ADD COLUMN emotion_before  VARCHAR(20),
+  ADD COLUMN emotion_during  VARCHAR(20),
+  ADD COLUMN emotion_after   VARCHAR(20);

--- a/server/src/modules/trades/repositories/trades.repository.js
+++ b/server/src/modules/trades/repositories/trades.repository.js
@@ -47,7 +47,7 @@ const TradesRepository = {
   /**
    * Persist a new trade
    *
-   * @param {Object} trade - { userId, symbol, tradeType, entryPrice, exitPrice, entryTime, exitTime, quantity, notes, strategy }
+   * @param {Object} trade - { userId, symbol, tradeType, entryPrice, exitPrice, entryTime, exitTime, quantity, notes, strategy, emotionBefore, emotionDuring, emotionAfter }
    * @returns {Object} - The newly created trade row
    */
   create: async ({
@@ -61,6 +61,9 @@ const TradesRepository = {
     quantity,
     notes,
     strategy,
+    emotionBefore,
+    emotionDuring,
+    emotionAfter,
   }) => {
     logger.debug("Inserting new trade", { userId, symbol });
 
@@ -70,8 +73,8 @@ const TradesRepository = {
 
     try {
       const { rows } = await query(
-        `INSERT INTO trades (user_id, symbol, trade_type, entry_price, exit_price, entry_time, exit_time, quantity, trade_status, closed_at, notes, strategy)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+        `INSERT INTO trades (user_id, symbol, trade_type, entry_price, exit_price, entry_time, exit_time, quantity, trade_status, closed_at, notes, strategy, emotion_before, emotion_during, emotion_after)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
         RETURNING *`,
         [
           userId,
@@ -86,6 +89,9 @@ const TradesRepository = {
           closedAt,
           notes || null,
           strategy || null,
+          emotionBefore || null,
+          emotionDuring || null,
+          emotionAfter || null,
         ],
       );
 
@@ -189,6 +195,9 @@ const TradesRepository = {
       strategy,
       tradeStatus,
       closedAt,
+      emotionBefore,
+      emotionDuring,
+      emotionAfter,
     },
   ) => {
     logger.debug("Updating trade in database", { tradeId });
@@ -206,8 +215,11 @@ const TradesRepository = {
             notes        = $8,
             strategy     = $9,
             trade_status = $10,
-            closed_at    = $11
-        WHERE trade_id = $12
+            closed_at    = $11,
+            emotion_before = $12,
+            emotion_during = $13,
+            emotion_after  = $14
+        WHERE trade_id = $15
         RETURNING *`,
         [
           symbol,
@@ -221,6 +233,9 @@ const TradesRepository = {
           strategy || null,
           tradeStatus,
           closedAt,
+          emotionBefore || null,
+          emotionDuring || null,
+          emotionAfter || null,
           tradeId,
         ],
       );

--- a/server/src/modules/trades/services/trades.service.js
+++ b/server/src/modules/trades/services/trades.service.js
@@ -95,6 +95,9 @@ const TradesService = {
       quantity: Number(tradeInput.quantity),
       notes: tradeInput.notes || null,
       strategy: tradeInput.strategy || null,
+      emotionBefore: tradeInput.emotionBefore || null,
+      emotionDuring: tradeInput.emotionDuring || null,
+      emotionAfter: tradeInput.emotionAfter || null,
     };
 
     // =========================
@@ -341,6 +344,9 @@ const TradesService = {
       strategy: tradeInput.strategy || null,
       tradeStatus,
       closedAt,
+      emotionBefore: tradeInput.emotionBefore || null,
+      emotionDuring: tradeInput.emotionDuring || null,
+      emotionAfter: tradeInput.emotionAfter || null,
     };
 
     // =========================

--- a/server/src/modules/trades/validation/trades.validation.js
+++ b/server/src/modules/trades/validation/trades.validation.js
@@ -1,5 +1,7 @@
 // /server/src/modules/trades/validation/trades.validation.js
 
+const { VALID_EMOTIONS } = require("../../../utils/constants");
+
 /**
  * Trade type enum
  * Shared across validation/service layers
@@ -117,6 +119,24 @@ function validateTrade(trade) {
       "exitTime",
     );
   }
+
+  // =========================
+  // Emotion validation
+  // =========================
+  const emotionBeforeError = validateEmotion(
+    trade.emotionBefore,
+    "emotionBefore",
+  );
+  if (emotionBeforeError) return emotionBeforeError;
+
+  const emotionDuringError = validateEmotion(
+    trade.emotionDuring,
+    "emotionDuring",
+  );
+  if (emotionDuringError) return emotionDuringError;
+
+  const emotionAfterError = validateEmotion(trade.emotionAfter, "emotionAfter");
+  if (emotionAfterError) return emotionAfterError;
 
   return null;
 }
@@ -264,6 +284,42 @@ function validateEditTrade(trade) {
     );
   }
 
+  // =========================
+  // Emotion validation
+  // =========================
+  const emotionBeforeError = validateEmotion(
+    trade.emotionBefore,
+    "emotionBefore",
+  );
+  if (emotionBeforeError) return emotionBeforeError;
+
+  const emotionDuringError = validateEmotion(
+    trade.emotionDuring,
+    "emotionDuring",
+  );
+  if (emotionDuringError) return emotionDuringError;
+
+  const emotionAfterError = validateEmotion(trade.emotionAfter, "emotionAfter");
+  if (emotionAfterError) return emotionAfterError;
+
+  return null;
+}
+
+/**
+ * Validates a single emotion field value
+ *
+ * @param {string} value - The emotion value to validate
+ * @param {string} field - The field name for the error message
+ * @returns {null | { message: string, field: string }}
+ */
+function validateEmotion(value, field) {
+  if (value == null || value === "") return null;
+  if (!VALID_EMOTIONS.includes(value)) {
+    return createValidationError(
+      `Invalid emotion value for ${field}. Must be one of: ${VALID_EMOTIONS.join(", ")}`,
+      field,
+    );
+  }
   return null;
 }
 
@@ -271,5 +327,6 @@ module.exports = {
   validateTrade,
   validateCloseTrade,
   validateEditTrade,
+  validateEmotion,
   TRADE_TYPES,
 };

--- a/server/src/utils/constants.js
+++ b/server/src/utils/constants.js
@@ -21,4 +21,25 @@ const SYMBOL_MULTIPLIERS = {
   M2K: 5,
 };
 
-module.exports = { SYMBOL_MULTIPLIERS };
+/**
+ * Valid emotional state values
+ * Used for trade journal entries (before, during, after)
+ */
+const VALID_EMOTIONS = Object.freeze([
+  "Calm",
+  "Confident",
+  "Focused",
+  "Excited",
+  "Neutral",
+  "Uncertain",
+  "Confused",
+  "Anxious",
+  "Nervous",
+  "Fearful",
+  "Greedy",
+  "Impatient",
+  "FOMO",
+  "Revenge",
+]);
+
+module.exports = { SYMBOL_MULTIPLIERS, VALID_EMOTIONS };

--- a/server/tests/api/trades.test.js
+++ b/server/tests/api/trades.test.js
@@ -680,4 +680,114 @@ describe("Trade API", () => {
     expect(res.status).toBe(400);
     expect(res.body.error.code).toBe("VALIDATION_ERROR");
   });
+
+  // =========================
+  // Test Case 1.22
+  // Create trade with emotions
+  // =========================
+  /**
+   * Validates that emotional state fields are persisted
+   * when provided on trade creation.
+   *
+   * EXPECTED:
+   * - HTTP 201
+   * - Returned trade includes emotion fields
+   */
+  it("creates a trade with emotional state", async () => {
+    const res = await request(app)
+      .post("/api/trades")
+      .set("Cookie", cookie)
+      .send({
+        ...openTrade(),
+        emotionBefore: "Calm",
+        emotionDuring: "Focused",
+        emotionAfter: "Confident",
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.emotion_before).toBe("Calm");
+    expect(res.body.data.emotion_during).toBe("Focused");
+    expect(res.body.data.emotion_after).toBe("Confident");
+  });
+
+  // =========================
+  // Test Case 1.23
+  // Emotion fields are optional
+  // =========================
+  /**
+   * Validates that trades can be created without emotion fields.
+   *
+   * EXPECTED:
+   * - HTTP 201
+   * - Emotion fields are null
+   */
+  it("creates a trade without emotional state", async () => {
+    const res = await request(app)
+      .post("/api/trades")
+      .set("Cookie", cookie)
+      .send(openTrade());
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.emotion_before).toBeNull();
+    expect(res.body.data.emotion_during).toBeNull();
+    expect(res.body.data.emotion_after).toBeNull();
+  });
+
+  // =========================
+  // Test Case 1.24
+  // Invalid emotion value rejected
+  // =========================
+  /**
+   * Validates that an invalid emotion value returns 400.
+   *
+   * EXPECTED:
+   * - HTTP 400
+   * - error code VALIDATION_ERROR
+   */
+  it("rejects invalid emotion values", async () => {
+    const res = await request(app)
+      .post("/api/trades")
+      .set("Cookie", cookie)
+      .send({
+        ...openTrade(),
+        emotionBefore: "Happy",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  // =========================
+  // Test Case 1.25
+  // Edit trade updates emotions
+  // =========================
+  /**
+   * Validates that emotional state is updated when editing a trade.
+   *
+   * EXPECTED:
+   * - HTTP 200
+   * - Emotion fields reflect updated values
+   */
+  it("updates emotional state when editing a trade", async () => {
+    const trade = await createOpenTrade(cookie);
+
+    const res = await request(app)
+      .put(`/api/trades/${trade.trade_id}`)
+      .set("Cookie", cookie)
+      .send({
+        symbol: "AAPL",
+        type: "BUY",
+        entryPrice: 100,
+        quantity: 1,
+        entryTime: "2026-04-21T09:00:00Z",
+        emotionBefore: "Anxious",
+        emotionDuring: "Calm",
+        emotionAfter: "Confident",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.emotion_before).toBe("Anxious");
+    expect(res.body.data.emotion_during).toBe("Calm");
+    expect(res.body.data.emotion_after).toBe("Confident");
+  });
 });


### PR DESCRIPTION
## Summary

Implements emotional state tracking on trade entries. Traders can now
record how they felt before, during, and after each trade using a
collapsible Journal section in the trade form and edit modal. Emotional
state is optional on all trades and existing trades are unaffected.

## Changes

### Backend
- `003_add_emotions_to_trades.sql` — new migration adding `emotion_before`,
  `emotion_during`, `emotion_after` columns to the trades table
- `constants.js` — added `VALID_EMOTIONS` list
- `trades.validation.js` — added `validateEmotion` helper, wired into
  `validateTrade` and `validateEditTrade`
- `trades.repository.js` — updated `create` and `updateTrade` to handle
  emotion fields
- `trades.service.js` — updated `createTrade` and `editTrade` normalization
  to pass emotion fields

### Frontend
- `components/JournalSection.jsx` — new collapsible component with emoji
  pill selectors for before, during, and after emotions
- `TradeEntry.jsx` — added emotion fields to form state, handler, and
  submit payload. Journal section added to trade form
- `EditTradeModal.jsx` — added emotion fields to form state and submit
  payload. Journal section auto-expands if emotions already set
- `formatters.js` — added `toLocalDateTimeInput` and `toUTCString` to
  handle timezone conversion for datetime inputs
- Fixed datetime display bug — times now stored as UTC and displayed
  in local time correctly across trade log and edit modal

### Tests
- `trades.test.js` — added tests 1.22 – 1.25

## Test Coverage

| Test | Description |
|------|-------------|
| 1.22 | Creates a trade with emotional state |
| 1.23 | Creates a trade without emotional state |
| 1.24 | Rejects invalid emotion values |
| 1.25 | Updates emotional state when editing a trade |

**Total: 50 → 54 passing tests**