### PR TITLE
feat: add emotion analytics endpoint and dashboard section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Built end to end across the full software development lifecycle:
 - **Backend engineering** — REST API, session auth, request tracing, error handling
 - **Frontend engineering** — React SPA, component design, client-side validation
 - **Data** — PostgreSQL schema design, versioned migrations, analytics queries
-- **Testing** — 54 tests across 4 suites, isolated test database, CI pipeline
+- **Testing** — 57 tests across 4 suites, isolated test database, CI pipeline
 - **DevOps** — Docker for local development, GitHub Actions CI/CD, production deployment across three platforms
 
 The goal was to build something genuinely useful while gaining hands-on experience with the tools, patterns, and workflows used in professional software development.
@@ -57,6 +57,7 @@ The goal was to build something genuinely useful while gaining hands-on experien
 - P&L over time — bar chart with day / week / month toggle
 - Win rate — total trades, wins, losses, breakevens
 - Symbol breakdown — ranked by total P&L with per-symbol win rate
+- Emotion insights — win rate by emotional state, most common emotion before wins and losses
 
 ### Authentication
 
@@ -129,16 +130,17 @@ server/                              # Node.js/Express backend
       auth/                          # Auth controller, service, repositories
       trades/                        # Trades controller, service, repository, validation
       analytics/                     # Analytics controller, service, repository
-    tests/                           # Jest test suites (54 tests, 4 suites)
+    tests/                           # Jest test suites (57 tests, 4 suites)
       api/
         auth.test.js                 # Authentication flows (12 tests)
-        trades.test.js               # Trade business logic (21 tests)
+        trades.test.js               # Trade business logic (25 tests)
         app.test.js                  # Infrastructure — requestId, concurrency (8 tests)
-        analytics.test.js            # Analytics endpoints (9 tests)
+        analytics.test.js            # Analytics endpoints (12 tests)
       fixtures/
         auth.js                      # Auth helpers
         trades.js                    # Trade fixtures
 
+package.json                         # Root package.json — coordinates build
 ```
 
 ### Request Flow
@@ -215,6 +217,7 @@ VITE_API_URL=http://localhost:5000
 ```bash
 psql -U postgres -d tradetrack -f server/src/db/migrations/001_initial_schema.sql
 psql -U postgres -d tradetrack -f server/src/db/migrations/002_add_entry_exit_time_to_trades.sql
+psql -U postgres -d tradetrack -f server/src/db/migrations/003_add_emotions_to_trades.sql
 ```
 
 ### 6. Start the Application
@@ -251,14 +254,14 @@ psql -U postgres -d tradetrack_test -f server/src/db/migrations/002_add_entry_ex
 cd server && npm test
 ```
 
-**54 tests across 4 suites:**
+**57 tests across 4 suites:**
 
 | Suite               | Tests | Coverage                                        |
 | ------------------- | ----- | ----------------------------------------------- |
 | `trades.test.js`    | 25    | Trade creation, close, edit, delete, validation |
 | `auth.test.js`      | 12    | Registration, login, logout, session management |
 | `app.test.js`       | 8     | Request tracing, concurrency, error shape       |
-| `analytics.test.js` | 9     | P&L by period, win rate, symbol breakdown       |
+| `analytics.test.js` | 12    | P&L by period, win rate, symbol breakdown       |
 
 ---
 
@@ -285,11 +288,12 @@ cd server && npm test
 
 ### Analytics
 
-| Method | Endpoint                                     | Description                       |
-| ------ | -------------------------------------------- | --------------------------------- |
-| GET    | `/api/analytics/pnl?period=day\|week\|month` | P&L grouped by period             |
-| GET    | `/api/analytics/win-rate`                    | Win rate across all closed trades |
-| GET    | `/api/analytics/symbols`                     | P&L and win rate by symbol        |
+| Method | Endpoint                                     | Description                              |
+| ------ | -------------------------------------------- | ---------------------------------------- |
+| GET    | `/api/analytics/pnl?period=day\|week\|month` | P&L grouped by period                    |
+| GET    | `/api/analytics/win-rate`                    | Win rate across all closed trades        |
+| GET    | `/api/analytics/symbols`                     | P&L and win rate by symbol               |
+| GET    | `/api/analytics/emotions`                    | Win rate and patterns by emotional state |
 
 ---
 

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -52,6 +52,21 @@ const PnLTooltip = ({ active, payload, label }) => {
   );
 };
 
+const EMOTION_EMOJIS = {
+  Calm:      "😌",
+  Confident: "💪",
+  Focused:   "🎯",
+  Excited:   "😄",
+  Neutral:   "😐",
+  Anxious:   "😰",
+  Nervous:   "😬",
+  Fearful:   "😨",
+  Greedy:    "🤑",
+  Impatient: "⏰",
+  FOMO:      "😱",
+  Revenge:   "😤",
+};
+
 // =========================
 // Component
 // =========================
@@ -66,6 +81,7 @@ export default function Dashboard() {
   const [pnlData, setPnlData] = useState([]);
   const [winRate, setWinRate] = useState(null);
   const [symbols, setSymbols] = useState([]);
+  const [emotions, setEmotions] = useState({ byEmotion: [], mostCommonWin: null, mostCommonLoss: null });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
@@ -98,7 +114,7 @@ export default function Dashboard() {
     setError("");
 
     try {
-      const [pnlRes, winRateRes, symbolsRes] = await Promise.all([
+      const [pnlRes, winRateRes, symbolsRes, emotionsRes] = await Promise.all([
         fetch(`${API_URL}/api/analytics/pnl?period=${selectedPeriod}`, {
           credentials: "include",
         }),
@@ -108,6 +124,9 @@ export default function Dashboard() {
         fetch(`${API_URL}/api/analytics/symbols`, {
           credentials: "include",
         }),
+        fetch(`${API_URL}/api/analytics/emotions`, {
+          credentials: "include",
+        }),
       ]);
 
       if (pnlRes.status === 401) {
@@ -115,15 +134,17 @@ export default function Dashboard() {
         return navigate("/login");
       }
 
-      const [pnlData, winRateData, symbolsData] = await Promise.all([
+      const [pnlData, winRateData, symbolsData, emotionsData] = await Promise.all([
         pnlRes.json(),
         winRateRes.json(),
         symbolsRes.json(),
+        emotionsRes.json(),
       ]);
 
       setPnlData(pnlData.data || []);
       setWinRate(winRateData.data || null);
       setSymbols(symbolsData.data || []);
+      setEmotions(emotionsData.data || { byEmotion: [], mostCommonWin: null, mostCommonLoss: null });
     } catch (err) {
       console.error("Analytics fetch error:", err);
       setError("Failed to load analytics. Please try again.");
@@ -319,6 +340,85 @@ export default function Dashboard() {
           </div>
         </section>
 
+        {/* EMOTION INSIGHTS */}
+        <section>
+          <h2 className="text-sm font-medium text-zinc-400 uppercase tracking-wider mb-4">
+            Emotion Insights
+          </h2>
+
+          <div className="bg-zinc-900 border border-zinc-800 rounded-2xl overflow-hidden">
+            {loading ? (
+              <div className="px-6 py-12 text-center text-zinc-600 text-sm">
+                Loading...
+              </div>
+            ) : !emotions || emotions.byEmotion.length === 0 ? (
+              <div className="px-6 py-12 text-center text-zinc-600 text-sm">
+                No emotion data yet. Start adding emotional state to your trades.
+              </div>
+            ) : (
+              <div className="p-6 space-y-6">
+
+                {/* Most common win/loss emotions */}
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <div className="bg-zinc-800 border border-zinc-700 rounded-xl px-5 py-4">
+                    <p className="text-xs text-zinc-500 uppercase tracking-wider mb-2">
+                      Most Common Before a Win
+                    </p>
+                    {emotions.mostCommonWin ? (
+                      <p className="text-lg font-semibold text-emerald-400">
+                        {EMOTION_EMOJIS[emotions.mostCommonWin]} {emotions.mostCommonWin}
+                      </p>
+                    ) : (
+                      <p className="text-sm text-zinc-600">No data</p>
+                    )}
+                  </div>
+
+                  <div className="bg-zinc-800 border border-zinc-700 rounded-xl px-5 py-4">
+                    <p className="text-xs text-zinc-500 uppercase tracking-wider mb-2">
+                      Most Common Before a Loss
+                    </p>
+                    {emotions.mostCommonLoss ? (
+                      <p className="text-lg font-semibold text-red-400">
+                        {EMOTION_EMOJIS[emotions.mostCommonLoss]} {emotions.mostCommonLoss}
+                      </p>
+                    ) : (
+                      <p className="text-sm text-zinc-600">No data</p>
+                    )}
+                  </div>
+                </div>
+
+                {/* Win rate by emotion table */}
+                <div>
+                  <div className="grid grid-cols-4 gap-4 px-4 py-3 border-b border-zinc-800 text-xs text-zinc-500 uppercase tracking-wider">
+                    <span>Emotion</span>
+                    <span className="text-right">Trades</span>
+                    <span className="text-right">Wins</span>
+                    <span className="text-right">Win Rate</span>
+                  </div>
+
+                  {emotions.byEmotion.map((e) => (
+                    <div
+                      key={e.emotion}
+                      className="grid grid-cols-4 gap-4 px-4 py-3 border-b border-zinc-800 last:border-0 text-sm items-center"
+                    >
+                      <span className="text-zinc-200">
+                        {EMOTION_EMOJIS[e.emotion]} {e.emotion}
+                      </span>
+                      <span className="text-right text-zinc-400">{e.total}</span>
+                      <span className="text-right text-zinc-400">{e.wins}</span>
+                      <span className={`text-right font-medium ${
+                        e.winRate >= 50 ? "text-emerald-400" : "text-red-400"
+                      }`}>
+                        {e.winRate}%
+                      </span>
+                    </div>
+                  ))}
+                </div>
+
+              </div>
+            )}
+          </div>
+        </section>
       </main>
     </div>
   );

--- a/server/src/modules/analytics/controllers/analytics.controller.js
+++ b/server/src/modules/analytics/controllers/analytics.controller.js
@@ -82,6 +82,24 @@ const AnalyticsController = {
       return sendError(res, err);
     }
   },
+
+  /**
+   * GET /api/analytics/emotions
+   */
+  getEmotionAnalytics: async (req, res) => {
+    logger.info("GET /api/analytics/emotions request received");
+
+    try {
+      const data = await AnalyticsService.getEmotionAnalytics(req.userId);
+
+      logger.info("Emotion analytics response sent");
+
+      return sendSuccess(res, { data });
+    } catch (err) {
+      logger.error("Failed to fetch emotion analytics", { error: err.message });
+      return sendError(res, err);
+    }
+  },
 };
 
 module.exports = AnalyticsController;

--- a/server/src/modules/analytics/repositories/analytics.repository.js
+++ b/server/src/modules/analytics/repositories/analytics.repository.js
@@ -35,6 +35,44 @@ const AnalyticsRepository = {
 
     return rows;
   },
+
+  /**
+   * Fetch closed trades with emotional state data
+   * Only returns trades where at least one emotion field is set
+   *
+   * @param {string} userId
+   * @returns {Array} closed trades with emotion fields
+   */
+  getEmotionTrades: async (userId) => {
+    logger.debug("Fetching emotion trades for analytics", { userId });
+
+    const { rows } = await query(
+      `SELECT
+        trade_id,
+        symbol,
+        trade_type,
+        entry_price,
+        exit_price,
+        quantity,
+        closed_at,
+        emotion_before,
+        emotion_during,
+        emotion_after
+      FROM trades
+      WHERE user_id      = $1
+        AND trade_status = 'closed'
+        AND exit_price   IS NOT NULL
+        AND (
+          emotion_before IS NOT NULL OR
+          emotion_during IS NOT NULL OR
+          emotion_after  IS NOT NULL
+        )
+      ORDER BY closed_at ASC`,
+      [userId],
+    );
+
+    return rows;
+  },
 };
 
 module.exports = AnalyticsRepository;

--- a/server/src/modules/analytics/routes/analytics.routes.js
+++ b/server/src/modules/analytics/routes/analytics.routes.js
@@ -15,5 +15,6 @@ const router = express.Router();
 router.get("/pnl", requireAuth, AnalyticsController.getPnLByPeriod);
 router.get("/win-rate", requireAuth, AnalyticsController.getWinRate);
 router.get("/symbols", requireAuth, AnalyticsController.getSymbolBreakdown);
+router.get("/emotions", requireAuth, AnalyticsController.getEmotionAnalytics);
 
 module.exports = router;

--- a/server/src/modules/analytics/services/analytics.service.js
+++ b/server/src/modules/analytics/services/analytics.service.js
@@ -168,6 +168,85 @@ const AnalyticsService = {
 
     return result;
   },
+
+  /**
+   * Emotion analytics — win rate grouped by emotion_before
+   * and most common emotions for winning vs losing trades
+   *
+   * @param {string} userId
+   * @returns {Object} {
+   *   byEmotion: [{ emotion, total, wins, winRate }],
+   *   mostCommonWin: string | null,
+   *   mostCommonLoss: string | null
+   * }
+   */
+  getEmotionAnalytics: async (userId) => {
+    logger.debug("Calculating emotion analytics", { userId });
+
+    const trades = await AnalyticsRepository.getEmotionTrades(userId);
+
+    if (trades.length === 0) {
+      return {
+        byEmotion: [],
+        mostCommonWin: null,
+        mostCommonLoss: null,
+      };
+    }
+
+    // =========================
+    // Group by emotion_before
+    // =========================
+    const emotionMap = {};
+    const winEmotions = {};
+    const lossEmotions = {};
+
+    for (const trade of trades) {
+      const pnl = calculateTradePnL(trade);
+      const isWin = pnl > 0;
+      const isLoss = pnl < 0;
+      const emotion = trade.emotion_before;
+
+      if (!emotion) continue;
+
+      if (!emotionMap[emotion]) {
+        emotionMap[emotion] = { emotion, total: 0, wins: 0 };
+      }
+
+      emotionMap[emotion].total += 1;
+      if (isWin) emotionMap[emotion].wins += 1;
+      if (isWin) winEmotions[emotion] = (winEmotions[emotion] || 0) + 1;
+      if (isLoss) lossEmotions[emotion] = (lossEmotions[emotion] || 0) + 1;
+    }
+
+    const byEmotion = Object.values(emotionMap)
+      .map((e) => ({
+        emotion: e.emotion,
+        total: e.total,
+        wins: e.wins,
+        winRate: Math.round((e.wins / e.total) * 10000) / 100,
+      }))
+      .sort((a, b) => b.winRate - a.winRate);
+
+    // Most common emotion before a win
+    const mostCommonWin =
+      Object.entries(winEmotions).length > 0
+        ? Object.entries(winEmotions).sort((a, b) => b[1] - a[1])[0][0]
+        : null;
+
+    // Most common emotion before a loss
+    const mostCommonLoss =
+      Object.entries(lossEmotions).length > 0
+        ? Object.entries(lossEmotions).sort((a, b) => b[1] - a[1])[0][0]
+        : null;
+
+    logger.debug("Emotion analytics calculated", {
+      emotionCount: byEmotion.length,
+      mostCommonWin,
+      mostCommonLoss,
+    });
+
+    return { byEmotion, mostCommonWin, mostCommonLoss };
+  },
 };
 
 module.exports = AnalyticsService;

--- a/server/tests/api/analytics.test.js
+++ b/server/tests/api/analytics.test.js
@@ -226,4 +226,70 @@ describe("Analytics API", () => {
     expect(winRateRes.status).toBe(401);
     expect(symbolRes.status).toBe(401);
   });
+
+  // =========================
+  // Test Case 4.10
+  // Emotion analytics — empty state
+  // =========================
+  /**
+   * Validates that emotion analytics returns empty state
+   * when no trades have emotion data.
+   */
+  it("returns empty state for emotion analytics when no emotion data exists", async () => {
+    await request(app)
+      .post("/api/trades")
+      .set("Cookie", cookie)
+      .send(validTrade());
+
+    const res = await request(app)
+      .get("/api/analytics/emotions")
+      .set("Cookie", cookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.byEmotion).toEqual([]);
+    expect(res.body.data.mostCommonWin).toBeNull();
+    expect(res.body.data.mostCommonLoss).toBeNull();
+  });
+
+  // =========================
+  // Test Case 4.11
+  // Emotion analytics — with data
+  // =========================
+  /**
+   * Validates emotion analytics calculates correctly
+   * for trades with emotion_before set.
+   */
+  it("returns emotion analytics for trades with emotion data", async () => {
+    await request(app)
+      .post("/api/trades")
+      .set("Cookie", cookie)
+      .send({
+        ...validTrade(),
+        emotionBefore: "Calm",
+      });
+
+    const res = await request(app)
+      .get("/api/analytics/emotions")
+      .set("Cookie", cookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.byEmotion.length).toBeGreaterThan(0);
+    expect(res.body.data.byEmotion[0].emotion).toBe("Calm");
+    expect(res.body.data.byEmotion[0].winRate).toBe(100);
+    expect(res.body.data.mostCommonWin).toBe("Calm");
+    expect(res.body.data.mostCommonLoss).toBeNull();
+  });
+
+  // =========================
+  // Test Case 4.12
+  // Emotion analytics — auth protection
+  // =========================
+  /**
+   * Validates that emotion analytics requires authentication.
+   */
+  it("returns 401 for unauthenticated emotion analytics request", async () => {
+    const res = await request(app).get("/api/analytics/emotions");
+
+    expect(res.status).toBe(401);
+  });
 });


### PR DESCRIPTION
## Summary

Implements the Emotion Analytics story. Adds a `GET /api/analytics/emotions`
endpoint that calculates win rate grouped by `emotion_before` and identifies
the most common emotion before winning and losing trades. A new Emotion
Insights section on the dashboard displays this data.

## Changes

### Backend
- `analytics.repository.js` — added `getEmotionTrades` query fetching
  closed trades with at least one emotion field set
- `analytics.service.js` — added `getEmotionAnalytics` calculating win
  rate by emotion and most common win/loss emotions
- `analytics.controller.js` — added `getEmotionAnalytics` handler
- `analytics.routes.js` — added `GET /emotions` route

### Tests
- `analytics.test.js` — added tests 4.10 – 4.12

### Frontend
- `Dashboard.jsx` — added Emotion Insights section with most common
  win/loss emotion cards and win rate by emotion table. Emotion analytics
  fetched alongside existing analytics on load. Fixed emotions state
  initialization to prevent crash when data is unavailable.

## Test Coverage

| Test | Description |
|------|-------------|
| 4.10 | Returns empty state when no emotion data exists |
| 4.11 | Returns correct emotion analytics for trades with emotion data |
| 4.12 | Returns 401 for unauthenticated requests |

**Total: 54 → 57 passing tests**