### PR TITLE
feat: add watchlist page with live quotes and symbol-level caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,6 +130,7 @@ jobs:
           psql -h localhost -U postgres -d tradetrack_test -f server/src/db/migrations/001_initial_schema.sql
           psql -h localhost -U postgres -d tradetrack_test -f server/src/db/migrations/002_add_entry_exit_time_to_trades.sql
           psql -h localhost -U postgres -d tradetrack_test -f server/src/db/migrations/003_add_emotions_to_trades.sql
+          psql -h localhost -U postgres -d tradetrack_test -f server/src/db/migrations/004_create_watchlist_items.sql
 
       # --------------------------------------------------------
       # Run the Jest test suite.

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -10,6 +10,7 @@ import Login from "./pages/Login";
 import Register from "./pages/Register";
 import TradeEntry from "./pages/TradeEntry";
 import Dashboard from "./pages/Dashboard";
+import Watchlist from "./pages/Watchlist";
 
 import ProtectedRoute from "./routes/ProtectedRoute";
 
@@ -76,6 +77,15 @@ function App() {
           element={
             <ProtectedRoute>
               <Dashboard />
+            </ProtectedRoute>
+          }
+        />
+
+        <Route
+          path="/watchlist"
+          element={
+            <ProtectedRoute>
+              <Watchlist />
             </ProtectedRoute>
           }
         />

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -180,6 +180,12 @@ export default function Dashboard() {
             >
               Trade Log
             </Link>
+            <Link
+              to="/watchlist"
+              className="text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-500 rounded-lg px-3 sm:px-4 py-2 transition"
+            >
+              Watchlist
+            </Link>
             <button
               onClick={handleLogout}
               className="text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-500 rounded-lg px-3 sm:px-4 py-2 transition"

--- a/client/src/pages/TradeEntry.jsx
+++ b/client/src/pages/TradeEntry.jsx
@@ -444,6 +444,13 @@ export default function TradeEntry() {
             >
               Dashboard
             </Link>
+
+            <Link
+              to="/watchlist"
+              className="text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-500 rounded-lg px-3 sm:px-4 py-2 transition"
+            >
+              Watchlist
+            </Link>
             
             <button
               onClick={handleLogout}

--- a/client/src/pages/Watchlist.jsx
+++ b/client/src/pages/Watchlist.jsx
@@ -1,0 +1,370 @@
+// /client/src/pages/Watchlist.jsx
+
+import { useEffect, useState } from "react";
+import { useNavigate, Link } from "react-router-dom";
+import { API_URL } from "../config/api.js";
+import { useAuth } from "../context/AuthContext";
+
+/**
+ * Futures proxy labels for display
+ */
+const FUTURES_LABELS = {
+  QQQ: "NQ",
+  SPY: "ES",
+  IWM: "RTY",
+  DIA: "YM",
+};
+
+export default function Watchlist() {
+  const navigate    = useNavigate();
+  const { logout }  = useAuth();
+
+  const [quotes, setQuotes]           = useState([]);
+  const [items, setItems]             = useState([]);
+  const [loading, setLoading]         = useState(true);
+  const [refreshing, setRefreshing]   = useState(false);
+  const [error, setError]             = useState("");
+  const [newSymbol, setNewSymbol]     = useState("");
+  const [addError, setAddError]       = useState("");
+  const [addLoading, setAddLoading]   = useState(false);
+  const [lastUpdated, setLastUpdated] = useState(null);
+
+  // =========================
+  // Handlers
+  // =========================
+  const handleLogout = async () => {
+    try {
+      await logout();
+      navigate("/login");
+    } catch (err) {
+      console.error("Logout error:", err);
+    }
+  };
+
+  const fetchQuotes = async () => {
+    setRefreshing(true);
+    setError("");
+
+    try {
+      const res  = await fetch(`${API_URL}/api/watchlist/quotes`, {
+        credentials: "include",
+      });
+
+      if (res.status === 401) {
+        await logout();
+        return navigate("/login");
+      }
+
+      const data = await res.json();
+
+      if (data.status === "success") {
+        setQuotes(data.data || []);
+        setLastUpdated(new Date());
+      }
+    } catch (err) {
+      console.error("Quotes fetch error:", err);
+      setError("Failed to load quotes. Please try again.");
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  const fetchWatchlist = async () => {
+    setLoading(true);
+
+    try {
+      const res  = await fetch(`${API_URL}/api/watchlist`, {
+        credentials: "include",
+      });
+
+      const data = await res.json();
+
+      if (data.status === "success") {
+        setItems(data.data || []);
+      }
+    } catch (err) {
+      console.error("Watchlist fetch error:", err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleAddSymbol = async () => {
+    if (!newSymbol.trim()) return;
+
+    setAddError("");
+    setAddLoading(true);
+
+    try {
+      const res  = await fetch(`${API_URL}/api/watchlist`, {
+        method:      "POST",
+        credentials: "include",
+        headers:     { "Content-Type": "application/json" },
+        body:        JSON.stringify({ symbol: newSymbol.trim().toUpperCase() }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok || data.status !== "success") {
+        setAddError(data.error?.message || "Failed to add symbol");
+        return;
+      }
+
+      setItems((prev) => [...prev, data.data]);
+      setNewSymbol("");
+      fetchQuotes();
+    } catch (err) {
+      console.error("Add symbol error:", err);
+      setAddError("Network error. Please try again.");
+    } finally {
+      setAddLoading(false);
+    }
+  };
+
+  const handleRemove = async (itemId, symbol) => {
+    try {
+      const res = await fetch(`${API_URL}/api/watchlist/${itemId}`, {
+        method:      "DELETE",
+        credentials: "include",
+      });
+
+      const data = await res.json();
+
+      if (data.status === "success") {
+        setItems((prev)  => prev.filter((i) => i.item_id !== itemId));
+        setQuotes((prev) => prev.filter((q) => q.symbol !== symbol));
+      }
+    } catch (err) {
+      console.error("Remove error:", err);
+    }
+  };
+
+  // =========================
+  // Effects
+  // =========================
+  useEffect(() => {
+    const init = async () => {
+      await fetchWatchlist();
+      await fetchQuotes();
+    };
+    init();
+  }, []);
+
+  // =========================
+  // Helpers
+  // =========================
+  const getChangeColor = (value) => {
+    if (value > 0) return "text-emerald-400";
+    if (value < 0) return "text-red-400";
+    return "text-zinc-400";
+  };
+
+  const formatChange = (value) => {
+    if (value == null) return "—";
+    const sign = value > 0 ? "+" : "";
+    return `${sign}${value.toFixed(2)}`;
+  };
+
+  const formatPercent = (value) => {
+    if (value == null) return "—";
+    const sign = value > 0 ? "+" : "";
+    return `${sign}${value.toFixed(2)}%`;
+  };
+
+  const formatPrice = (value) => {
+    if (value == null || value === 0) return "—";
+    return value.toLocaleString("en-US", {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+  };
+
+  // Build a map of symbol → quote for easy lookup
+  const quoteMap = quotes.reduce((acc, q) => {
+    acc[q.symbol] = q;
+    return acc;
+  }, {});
+
+  // =========================
+  // UI
+  // =========================
+  return (
+    <div className="min-h-screen bg-zinc-950 text-white">
+
+      {/* HEADER */}
+      <header className="border-b border-zinc-800 bg-zinc-900 px-4 sm:px-6 py-4">
+        <div className="max-w-6xl mx-auto flex items-center justify-between">
+          <h1 className="text-xl font-bold tracking-tight">
+            Trade<span className="text-emerald-400">Track</span>
+          </h1>
+          <div className="flex items-center gap-2 sm:gap-4">
+            <Link
+              to="/dashboard"
+              className="text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-500 rounded-lg px-3 sm:px-4 py-2 transition"
+            >
+              Dashboard
+            </Link>
+            <Link
+              to="/trade"
+              className="text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-500 rounded-lg px-3 sm:px-4 py-2 transition"
+            >
+              Trade Log
+            </Link>
+            <button
+              onClick={handleLogout}
+              className="text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-500 rounded-lg px-3 sm:px-4 py-2 transition"
+            >
+              Logout
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-6xl mx-auto px-4 sm:px-6 py-6 sm:py-8 space-y-6">
+
+        {/* PAGE HEADER */}
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold text-white">Watchlist</h2>
+            {lastUpdated && (
+              <p className="text-xs text-zinc-500 mt-0.5">
+                Updated {lastUpdated.toLocaleTimeString("en-US", {
+                  hour:   "2-digit",
+                  minute: "2-digit",
+                  second: "2-digit",
+                })}
+              </p>
+            )}
+          </div>
+          <button
+            onClick={fetchQuotes}
+            disabled={refreshing}
+            className="text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-500 rounded-lg px-4 py-2 transition disabled:opacity-50"
+          >
+            {refreshing ? "Refreshing..." : "Refresh"}
+          </button>
+        </div>
+
+        {error && (
+          <p className="text-sm text-red-400 bg-red-950 border border-red-800 rounded-lg px-4 py-2.5">
+            {error}
+          </p>
+        )}
+
+        {/* ADD SYMBOL */}
+        <div className="bg-zinc-900 border border-zinc-800 rounded-2xl p-4">
+          <div className="flex gap-3">
+            <input
+              value={newSymbol}
+              onChange={(e) => setNewSymbol(e.target.value.toUpperCase())}
+              onKeyDown={(e) => e.key === "Enter" && handleAddSymbol()}
+              placeholder="Add symbol e.g. AAPL, QQQ"
+              className="flex-1 bg-zinc-800 border border-zinc-700 text-white placeholder-zinc-600 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent transition"
+            />
+            <button
+              onClick={handleAddSymbol}
+              disabled={addLoading || !newSymbol.trim()}
+              className="bg-emerald-500 hover:bg-emerald-400 disabled:opacity-50 text-zinc-950 font-semibold rounded-lg px-5 py-2.5 text-sm transition"
+            >
+              {addLoading ? "Adding..." : "Add"}
+            </button>
+          </div>
+          {addError && (
+            <p className="text-xs text-red-400 mt-2">{addError}</p>
+          )}
+        </div>
+
+        {/* WATCHLIST TABLE */}
+        <div className="bg-zinc-900 border border-zinc-800 rounded-2xl overflow-hidden">
+
+          {/* TABLE HEADER — desktop */}
+          <div className="hidden sm:grid grid-cols-5 gap-4 px-6 py-3 border-b border-zinc-800 text-xs text-zinc-500 uppercase tracking-wider">
+            <span>Symbol</span>
+            <span className="text-right">Price</span>
+            <span className="text-right">Change</span>
+            <span className="text-right">Change %</span>
+            <span></span>
+          </div>
+
+          {loading ? (
+            <div className="px-6 py-12 text-center text-zinc-600 text-sm">
+              Loading...
+            </div>
+          ) : items.length === 0 ? (
+            <div className="px-6 py-12 text-center text-zinc-600 text-sm">
+              Your watchlist is empty. Add a symbol above.
+            </div>
+          ) : (
+            items.map((item) => {
+              const quote = quoteMap[item.symbol];
+              const label = FUTURES_LABELS[item.symbol];
+
+              return (
+                <div key={item.item_id}>
+
+                  {/* DESKTOP ROW */}
+                  <div className="hidden sm:grid grid-cols-5 gap-4 px-6 py-4 border-b border-zinc-800 last:border-0 hover:bg-zinc-800/50 transition text-sm items-center">
+                    <div>
+                      <span className="font-semibold text-white">{item.symbol}</span>
+                      {label && (
+                        <span className="ml-2 text-xs text-zinc-500">({label})</span>
+                      )}
+                    </div>
+                    <span className="text-right text-zinc-300">
+                      {quote ? formatPrice(quote.price) : "—"}
+                    </span>
+                    <span className={`text-right font-medium ${quote ? getChangeColor(quote.change) : "text-zinc-500"}`}>
+                      {quote ? formatChange(quote.change) : "—"}
+                    </span>
+                    <span className={`text-right font-medium ${quote ? getChangeColor(quote.changePercent) : "text-zinc-500"}`}>
+                      {quote ? formatPercent(quote.changePercent) : "—"}
+                    </span>
+                    <div className="flex justify-end">
+                      <button
+                        onClick={() => handleRemove(item.item_id, item.symbol)}
+                        className="text-xs text-zinc-600 hover:text-red-400 transition"
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  </div>
+
+                  {/* MOBILE CARD */}
+                  <div className="sm:hidden px-4 py-4 border-b border-zinc-800 last:border-0">
+                    <div className="flex items-center justify-between mb-2">
+                      <div>
+                        <span className="font-semibold text-white">{item.symbol}</span>
+                        {label && (
+                          <span className="ml-2 text-xs text-zinc-500">({label})</span>
+                        )}
+                      </div>
+                      <button
+                        onClick={() => handleRemove(item.item_id, item.symbol)}
+                        className="text-xs text-zinc-600 hover:text-red-400 transition"
+                      >
+                        Remove
+                      </button>
+                    </div>
+                    <div className="flex items-center gap-4 text-sm">
+                      <span className="text-zinc-300">
+                        {quote ? formatPrice(quote.price) : "—"}
+                      </span>
+                      <span className={`font-medium ${quote ? getChangeColor(quote.change) : "text-zinc-500"}`}>
+                        {quote ? formatChange(quote.change) : "—"}
+                      </span>
+                      <span className={`font-medium ${quote ? getChangeColor(quote.changePercent) : "text-zinc-500"}`}>
+                        {quote ? formatPercent(quote.changePercent) : "—"}
+                      </span>
+                    </div>
+                  </div>
+
+                </div>
+              );
+            })
+          )}
+        </div>
+
+      </main>
+    </div>
+  );
+}

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -9,6 +9,7 @@ const requestLogger = require("./middleware/requestLogger.middleware");
 const authRoutes = require("./modules/auth/routes/auth.routes");
 const tradeRoutes = require("./modules/trades/routes/trades.route");
 const analyticsRoutes = require("./modules/analytics/routes/analytics.routes");
+const watchlistRoutes = require("./modules/watchlist/routes/watchlist.routes");
 
 const app = express();
 
@@ -47,6 +48,7 @@ app.use(requestLogger);
 app.use("/api/auth", authRoutes);
 app.use("/api/trades", tradeRoutes);
 app.use("/api/analytics", analyticsRoutes);
+app.use("/api/watchlist", watchlistRoutes);
 
 /**
  * HEALTH CHECK

--- a/server/src/db/migrations/004_create_watchlist_items.sql
+++ b/server/src/db/migrations/004_create_watchlist_items.sql
@@ -1,0 +1,13 @@
+-- /server/src/db/migrations/004_create_watchlist_items.sql
+-- Creates the watchlist_items table for storing user watchlist tickers.
+-- Each user has their own list of symbols with a position for ordering.
+-- position allows users to reorder their watchlist in the future.
+
+CREATE TABLE watchlist_items (
+  item_id    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+  symbol     VARCHAR(20) NOT NULL,
+  position   INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(user_id, symbol)
+);

--- a/server/src/modules/watchlist/controllers/watchlist.controller.js
+++ b/server/src/modules/watchlist/controllers/watchlist.controller.js
@@ -1,0 +1,111 @@
+// /server/src/modules/watchlist/controllers/watchlist.controller.js
+
+const WatchlistService = require("../services/watchlist.service");
+const createLogger = require("../../../utils/logger");
+
+const logger = createLogger("watchlist.controller");
+
+const sendSuccess = (res, { statusCode = 200, message, data }) => {
+  return res.status(statusCode).json({
+    status: "success",
+    ...(message && { message }),
+    ...(data !== undefined && { data }),
+  });
+};
+
+const sendError = (res, err) => {
+  const statusCode = err.status || 500;
+  const message =
+    statusCode === 500
+      ? "Internal server error"
+      : err.message || "Something went wrong";
+  const code = err.code || (statusCode === 500 ? "INTERNAL_ERROR" : "ERROR");
+
+  return res.status(statusCode).json({ error: { message, code } });
+};
+
+const WatchlistController = {
+  /**
+   * GET /api/watchlist
+   * Get watchlist items for the authenticated user
+   */
+  getWatchlist: async (req, res) => {
+    logger.info("GET /api/watchlist request received");
+
+    try {
+      const items = await WatchlistService.getWatchlist(req.userId);
+
+      return sendSuccess(res, { data: items });
+    } catch (err) {
+      logger.error("Failed to get watchlist", { error: err.message });
+      return sendError(res, err);
+    }
+  },
+
+  /**
+   * GET /api/watchlist/quotes
+   * Fetch live quotes for all watchlist symbols
+   */
+  getQuotes: async (req, res) => {
+    logger.info("GET /api/watchlist/quotes request received");
+
+    try {
+      const quotes = await WatchlistService.getQuotes(req.userId);
+
+      return sendSuccess(res, { data: quotes });
+    } catch (err) {
+      logger.error("Failed to fetch quotes", { error: err.message });
+      return sendError(res, err);
+    }
+  },
+
+  /**
+   * POST /api/watchlist
+   * Add a ticker to the watchlist
+   */
+  addItem: async (req, res) => {
+    const { symbol } = req.body;
+
+    logger.info("POST /api/watchlist request received", { symbol });
+
+    if (!symbol) {
+      return res.status(400).json({
+        error: { message: "Symbol is required", code: "VALIDATION_ERROR" },
+      });
+    }
+
+    try {
+      const item = await WatchlistService.addItem(req.userId, symbol);
+
+      return sendSuccess(res, {
+        statusCode: 201,
+        message: `${symbol.toUpperCase()} added to watchlist`,
+        data: item,
+      });
+    } catch (err) {
+      logger.error("Failed to add watchlist item", { error: err.message });
+      return sendError(res, err);
+    }
+  },
+
+  /**
+   * DELETE /api/watchlist/:id
+   * Remove a ticker from the watchlist
+   */
+  removeItem: async (req, res) => {
+    const { id } = req.params;
+
+    logger.info("DELETE /api/watchlist/:id request received", { itemId: id });
+
+    try {
+      await WatchlistService.removeItem(id, req.userId);
+
+      return sendSuccess(res, { message: "Item removed from watchlist" });
+    } catch (err) {
+      logger.error("Failed to remove watchlist item", { error: err.message });
+      return sendError(res, err);
+    }
+  },
+};
+
+module.exports = WatchlistController;

--- a/server/src/modules/watchlist/repositories/watchlist.repository.js
+++ b/server/src/modules/watchlist/repositories/watchlist.repository.js
@@ -1,0 +1,113 @@
+// /server/src/modules/watchlist/repositories/watchlist.repository.js
+
+const { query } = require("../../../db/config/db");
+const createLogger = require("../../../utils/logger");
+const { handleDbError } = require("../../../utils/dbErrorHandler");
+
+const logger = createLogger("watchlist.repository");
+
+const WatchlistRepository = {
+  /**
+   * Get all watchlist items for a user ordered by position
+   *
+   * @param {string} userId
+   * @returns {Array} watchlist items
+   */
+  findAll: async (userId) => {
+    logger.debug("Fetching watchlist items", { userId });
+
+    const { rows } = await query(
+      `SELECT item_id, symbol, position, created_at
+       FROM watchlist_items
+       WHERE user_id = $1
+       ORDER BY position ASC, created_at ASC`,
+      [userId],
+    );
+
+    return rows;
+  },
+
+  /**
+   * Add a ticker to the watchlist
+   *
+   * @param {string} userId
+   * @param {string} symbol
+   * @param {number} position
+   * @returns {Object} the new watchlist item
+   */
+  addItem: async (userId, symbol, position) => {
+    logger.debug("Adding watchlist item", { userId, symbol });
+
+    try {
+      const { rows } = await query(
+        `INSERT INTO watchlist_items (user_id, symbol, position)
+         VALUES ($1, $2, $3)
+         RETURNING *`,
+        [userId, symbol.toUpperCase(), position],
+      );
+
+      logger.debug("Watchlist item added", { symbol });
+
+      return rows[0];
+    } catch (error) {
+      handleDbError(error);
+    }
+  },
+
+  /**
+   * Remove a ticker from the watchlist
+   *
+   * @param {string} itemId
+   * @param {string} userId
+   * @returns {void}
+   */
+  removeItem: async (itemId, userId) => {
+    logger.debug("Removing watchlist item", { itemId });
+
+    try {
+      await query(
+        `DELETE FROM watchlist_items
+         WHERE item_id = $1 AND user_id = $2`,
+        [itemId, userId],
+      );
+
+      logger.debug("Watchlist item removed", { itemId });
+    } catch (error) {
+      handleDbError(error);
+    }
+  },
+
+  /**
+   * Count items for a user
+   *
+   * @param {string} userId
+   * @returns {number}
+   */
+  countItems: async (userId) => {
+    const { rows } = await query(
+      `SELECT COUNT(*) FROM watchlist_items WHERE user_id = $1`,
+      [userId],
+    );
+
+    return parseInt(rows[0].count, 10);
+  },
+
+  /**
+   * Check if a symbol already exists for a user
+   *
+   * @param {string} userId
+   * @param {string} symbol
+   * @returns {boolean}
+   */
+  symbolExists: async (userId, symbol) => {
+    const { rows } = await query(
+      `SELECT 1 FROM watchlist_items
+       WHERE user_id = $1 AND symbol = $2`,
+      [userId, symbol.toUpperCase()],
+    );
+
+    return rows.length > 0;
+  },
+};
+
+module.exports = WatchlistRepository;

--- a/server/src/modules/watchlist/routes/watchlist.routes.js
+++ b/server/src/modules/watchlist/routes/watchlist.routes.js
@@ -1,0 +1,16 @@
+// /server/src/modules/watchlist/routes/watchlist.routes.js
+
+const express = require("express");
+const WatchlistController = require("../controllers/watchlist.controller");
+const authMiddleware = require("../../../middleware/auth.middleware");
+
+const router = express.Router();
+
+router.use(authMiddleware);
+
+router.get("/", WatchlistController.getWatchlist);
+router.get("/quotes", WatchlistController.getQuotes);
+router.post("/", WatchlistController.addItem);
+router.delete("/:id", WatchlistController.removeItem);
+
+module.exports = router;

--- a/server/src/modules/watchlist/services/watchlist.service.js
+++ b/server/src/modules/watchlist/services/watchlist.service.js
@@ -1,0 +1,213 @@
+// /server/src/modules/watchlist/services/watchlist.service.js
+
+const WatchlistRepository = require("../repositories/watchlist.repository");
+const createLogger = require("../../../utils/logger");
+
+const logger = createLogger("watchlist.service");
+
+const FINNHUB_API_KEY = process.env.FINNHUB_API_KEY;
+const FINNHUB_BASE_URL = "https://finnhub.io/api/v1";
+
+/**
+ * Futures proxy labels
+ * Maps ETF symbols to their futures equivalents for display
+ */
+const FUTURES_PROXIES = {
+  QQQ: "NQ",
+  SPY: "ES",
+  IWM: "RTY",
+  DIA: "YM",
+};
+
+/**
+ * Default watchlist symbols for new users
+ */
+const DEFAULT_SYMBOLS = [
+  "QQQ",
+  "SPY",
+  "IWM",
+  "DIA",
+  "NVDA",
+  "AAPL",
+  "MSFT",
+  "AMZN",
+  "META",
+  "TSLA",
+];
+
+/**
+ * Quote Cache
+ *
+ * Caches quotes at the symbol level for 60 seconds.
+ * Shared across all users — reduces Finnhub API calls
+ * for commonly watched symbols (QQQ, SPY, NVDA etc.)
+ *
+ * Key:   symbol string
+ * Value: { data: quote, fetchedAt: timestamp }
+ *
+ * Cache lives as long as the server process runs.
+ * A server restart clears it — acceptable for this use case.
+ */
+const quoteCache = {};
+const CACHE_TTL_MS = 60 * 1000; // 60 seconds
+
+/**
+ * Fetch a quote for a single symbol from Finnhub
+ * Returns cached result if fetched within the last 60 seconds
+ *
+ * @param {string} symbol
+ * @returns {Object} { symbol, label, price, change, changePercent, previousClose }
+ */
+const fetchQuote = async (symbol) => {
+  const cached = quoteCache[symbol];
+  const now = Date.now();
+
+  // Return cached quote if still fresh
+  if (cached && now - cached.fetchedAt < CACHE_TTL_MS) {
+    logger.debug("Returning cached quote", { symbol });
+    return cached.data;
+  }
+
+  const url = `${FINNHUB_BASE_URL}/quote?symbol=${symbol}&token=${FINNHUB_API_KEY}`;
+  const res = await fetch(url);
+
+  // Rate limited — return stale cache if available, otherwise throw
+  if (res.status === 429) {
+    if (cached) {
+      logger.warn("Rate limited by Finnhub — returning stale cache", {
+        symbol,
+      });
+      return cached.data;
+    }
+
+    const err = new Error("Rate limit reached. Please try again in a moment.");
+    err.code = "RATE_LIMIT";
+    err.status = 429;
+    throw err;
+  }
+
+  const data = await res.json();
+
+  const quote = {
+    symbol,
+    label: FUTURES_PROXIES[symbol] || null,
+    price: data.c || null,
+    change: data.d || null,
+    changePercent: data.dp || null,
+    previousClose: data.pc || null,
+  };
+
+  // Store in cache
+  quoteCache[symbol] = {
+    data: quote,
+    fetchedAt: now,
+  };
+
+  logger.debug("Quote fetched and cached", { symbol });
+
+  return quote;
+};
+
+const WatchlistService = {
+  /**
+   * Get watchlist items for a user
+   * Seeds default watchlist if user has none
+   *
+   * @param {string} userId
+   * @returns {Array} watchlist items
+   */
+  getWatchlist: async (userId) => {
+    logger.debug("Getting watchlist", { userId });
+
+    const items = await WatchlistRepository.findAll(userId);
+
+    // Seed default watchlist for new users
+    if (items.length === 0) {
+      logger.debug("Seeding default watchlist", { userId });
+
+      for (let i = 0; i < DEFAULT_SYMBOLS.length; i++) {
+        await WatchlistRepository.addItem(userId, DEFAULT_SYMBOLS[i], i);
+      }
+
+      return WatchlistRepository.findAll(userId);
+    }
+
+    return items;
+  },
+
+  /**
+   * Add a ticker to the watchlist
+   *
+   * BUSINESS RULES:
+   * - Symbol must not already exist in the watchlist
+   * - Maximum 30 items per watchlist
+   *
+   * @param {string} userId
+   * @param {string} symbol
+   * @returns {Object} the new watchlist item
+   */
+  addItem: async (userId, symbol) => {
+    logger.debug("Adding item to watchlist", { userId, symbol });
+
+    const exists = await WatchlistRepository.symbolExists(userId, symbol);
+
+    if (exists) {
+      const err = new Error(`${symbol} is already in your watchlist`);
+      err.code = "DUPLICATE_ERROR";
+      err.status = 409;
+      throw err;
+    }
+
+    const count = await WatchlistRepository.countItems(userId);
+
+    if (count >= 30) {
+      const err = new Error("Watchlist limit reached. Maximum 30 items.");
+      err.code = "VALIDATION_ERROR";
+      err.status = 400;
+      throw err;
+    }
+
+    return WatchlistRepository.addItem(userId, symbol, count);
+  },
+
+  /**
+   * Remove a ticker from the watchlist
+   *
+   * @param {string} itemId
+   * @param {string} userId
+   * @returns {void}
+   */
+  removeItem: async (itemId, userId) => {
+    logger.debug("Removing item from watchlist", { itemId, userId });
+
+    await WatchlistRepository.removeItem(itemId, userId);
+
+    logger.info("Watchlist item removed", { itemId });
+  },
+
+  /**
+   * Fetch live quotes for all watchlist symbols
+   * Uses symbol-level cache to reduce Finnhub API calls
+   *
+   * @param {string} userId
+   * @returns {Array} quotes with price data
+   */
+  getQuotes: async (userId) => {
+    logger.debug("Fetching quotes for watchlist", { userId });
+
+    const items = await WatchlistRepository.findAll(userId);
+
+    if (items.length === 0) return [];
+
+    // Fetch all quotes in parallel
+    const quotes = await Promise.all(
+      items.map((item) => fetchQuote(item.symbol)),
+    );
+
+    logger.debug("Quotes fetched", { count: quotes.length });
+
+    return quotes;
+  },
+};
+
+module.exports = WatchlistService;


### PR DESCRIPTION
closes #90 

## Summary

Implements the Watchlist feature. Adds a dedicated `/watchlist` page
where users can monitor stocks and ETF proxies for futures instruments.
Prices are fetched from Finnhub's free tier API via the backend to
protect the API key. A symbol-level cache reduces API calls across
users sharing common symbols.

## Changes

### Backend
- `004_create_watchlist_items.sql` — new migration creating
  `watchlist_items` table with user_id, symbol, position, created_at
- `watchlist.repository.js` — findAll, addItem, removeItem,
  countItems, symbolExists
- `watchlist.service.js` — getWatchlist, addItem, removeItem,
  getQuotes with 60 second symbol-level in-memory cache and
  Finnhub rate limit handling
- `watchlist.controller.js` — getWatchlist, getQuotes, addItem,
  removeItem handlers
- `watchlist.routes.js` — GET /, GET /quotes, POST /, DELETE /:id
- `app.js` — registered `/api/watchlist` routes

### Frontend
- `pages/Watchlist.jsx` — new page with add symbol input, quote
  table (desktop) and card layout (mobile), refresh button with
  last updated timestamp, remove button per row
- `App.jsx` — registered `/watchlist` as a protected route
- `TradeEntry.jsx` — added Watchlist navigation link to header
- `Dashboard.jsx` — added Watchlist navigation link to header

## Features

- Default watchlist seeded on first login: QQQ, SPY, IWM, DIA,
  NVDA, AAPL, MSFT, AMZN, META, TSLA
- ETF proxies labeled with futures equivalents: QQQ (NQ), SPY (ES),
  IWM (RTY), DIA (YM)
- Manual refresh pattern to stay within Finnhub free tier limits
- Stale cache returned on rate limit — degraded but not broken
- Maximum 30 items per watchlist
- Duplicate symbol detection

## Environment Variables

```env
FINNHUB_API_KEY=your_finnhub_api_key
```

**Total: 57 passing tests**