### PR TITLE
feat: add equity curve endpoint and dashboard chart

### DIFF
--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -10,6 +10,8 @@ import { formatCurrency } from "../utils/formatters";
 import {
   BarChart,
   Bar,
+  LineChart,
+  Line,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -39,6 +41,20 @@ import { useNavigate, Link } from "react-router-dom";
 // Custom Tooltip for chart
 // =========================
 const PnLTooltip = ({ active, payload, label }) => {
+  if (!active || !payload?.length) return null;
+
+  const value = payload[0].value;
+  const color = value >= 0 ? "text-emerald-400" : "text-red-400";
+
+  return (
+    <div className="bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm">
+      <p className="text-zinc-400 mb-1">{label}</p>
+      <p className={`font-semibold ${color}`}>{formatCurrency(value)}</p>
+    </div>
+  );
+};
+
+const EquityTooltip = ({ active, payload, label }) => {
   if (!active || !payload?.length) return null;
 
   const value = payload[0].value;
@@ -82,6 +98,7 @@ export default function Dashboard() {
   const [winRate, setWinRate] = useState(null);
   const [symbols, setSymbols] = useState([]);
   const [emotions, setEmotions] = useState({ byEmotion: [], mostCommonWin: null, mostCommonLoss: null });
+  const [equityCurve, setEquityCurve] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
@@ -114,7 +131,7 @@ export default function Dashboard() {
     setError("");
 
     try {
-      const [pnlRes, winRateRes, symbolsRes, emotionsRes] = await Promise.all([
+      const [pnlRes, winRateRes, symbolsRes, emotionsRes, equityRes] = await Promise.all([
         fetch(`${API_URL}/api/analytics/pnl?period=${selectedPeriod}`, {
           credentials: "include",
         }),
@@ -127,6 +144,9 @@ export default function Dashboard() {
         fetch(`${API_URL}/api/analytics/emotions`, {
           credentials: "include",
         }),
+        fetch(`${API_URL}/api/analytics/equity-curve`, { 
+          credentials: "include" 
+        }),
       ]);
 
       if (pnlRes.status === 401) {
@@ -134,17 +154,19 @@ export default function Dashboard() {
         return navigate("/login");
       }
 
-      const [pnlData, winRateData, symbolsData, emotionsData] = await Promise.all([
+      const [pnlData, winRateData, symbolsData, emotionsData, equityData] = await Promise.all([
         pnlRes.json(),
         winRateRes.json(),
         symbolsRes.json(),
         emotionsRes.json(),
+        equityRes.json(),
       ]);
 
       setPnlData(pnlData.data || []);
       setWinRate(winRateData.data || null);
       setSymbols(symbolsData.data || []);
       setEmotions(emotionsData.data || { byEmotion: [], mostCommonWin: null, mostCommonLoss: null });
+      setEquityCurve(equityData.data || []);
     } catch (err) {
       console.error("Analytics fetch error:", err);
       setError("Failed to load analytics. Please try again.");
@@ -237,6 +259,59 @@ export default function Dashboard() {
             </div>
           </section>
         )}
+
+        {/* EQUITY CURVE */}
+        <section>
+          <h2 className="text-sm font-medium text-zinc-400 uppercase tracking-wider mb-4">
+            Equity Curve
+          </h2>
+
+          <div className="bg-zinc-900 border border-zinc-800 rounded-2xl p-6">
+            {loading ? (
+              <div className="h-64 flex items-center justify-center text-zinc-600 text-sm">
+                Loading...
+              </div>
+            ) : equityCurve.length === 0 ? (
+              <div className="h-64 flex items-center justify-center text-zinc-600 text-sm">
+                No closed trades yet. Close some trades to see your equity curve.
+              </div>
+            ) : (
+              <ResponsiveContainer width="100%" height={280}>
+                <LineChart
+                  data={equityCurve}
+                  margin={{ top: 4, right: 4, left: 8, bottom: 4 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
+                  <XAxis
+                    dataKey="date"
+                    tick={{ fill: "#71717a", fontSize: 11 }}
+                    axisLine={{ stroke: "#3f3f46" }}
+                    tickLine={false}
+                  />
+                  <YAxis
+                    tick={{ fill: "#71717a", fontSize: 11 }}
+                    axisLine={{ stroke: "#3f3f46" }}
+                    tickLine={false}
+                    tickFormatter={(v) => `$${v.toLocaleString()}`}
+                  />
+                  <Tooltip content={<EquityTooltip />} />
+                  <Line
+                    type="monotone"
+                    dataKey="cumulativePnl"
+                    stroke={
+                      equityCurve[equityCurve.length - 1]?.cumulativePnl >= 0
+                        ? "#34d399"
+                        : "#f87171"
+                    }
+                    strokeWidth={2}
+                    dot={false}
+                    activeDot={{ r: 4, fill: "#34d399" }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            )}
+          </div>
+        </section>
 
         {/* P&L OVER TIME */}
         <section>

--- a/server/src/modules/analytics/controllers/analytics.controller.js
+++ b/server/src/modules/analytics/controllers/analytics.controller.js
@@ -100,6 +100,24 @@ const AnalyticsController = {
       return sendError(res, err);
     }
   },
+
+  /**
+   * GET /api/analytics/equity-curve
+   */
+  getEquityCurve: async (req, res) => {
+    logger.info("GET /api/analytics/equity-curve request received");
+
+    try {
+      const data = await AnalyticsService.getEquityCurve(req.userId);
+
+      logger.info("Equity curve response sent", { points: data.length });
+
+      return sendSuccess(res, { data });
+    } catch (err) {
+      logger.error("Failed to fetch equity curve", { error: err.message });
+      return sendError(res, err);
+    }
+  },
 };
 
 module.exports = AnalyticsController;

--- a/server/src/modules/analytics/repositories/analytics.repository.js
+++ b/server/src/modules/analytics/repositories/analytics.repository.js
@@ -73,6 +73,35 @@ const AnalyticsRepository = {
 
     return rows;
   },
+
+  /**
+   * Fetch closed trades for equity curve calculation
+   * Returns trade P&L components ordered by closed_at
+   *
+   * @param {string} userId
+   * @returns {Array} closed trades with fields needed for equity curve
+   */
+  getEquityCurveData: async (userId) => {
+    logger.debug("Fetching equity curve data", { userId });
+
+    const { rows } = await query(
+      `SELECT
+        symbol,
+        trade_type,
+        entry_price,
+        exit_price,
+        quantity,
+        closed_at
+      FROM trades
+      WHERE user_id      = $1
+        AND trade_status = 'closed'
+        AND exit_price   IS NOT NULL
+      ORDER BY closed_at ASC`,
+      [userId],
+    );
+
+    return rows;
+  },
 };
 
 module.exports = AnalyticsRepository;

--- a/server/src/modules/analytics/routes/analytics.routes.js
+++ b/server/src/modules/analytics/routes/analytics.routes.js
@@ -16,5 +16,6 @@ router.get("/pnl", requireAuth, AnalyticsController.getPnLByPeriod);
 router.get("/win-rate", requireAuth, AnalyticsController.getWinRate);
 router.get("/symbols", requireAuth, AnalyticsController.getSymbolBreakdown);
 router.get("/emotions", requireAuth, AnalyticsController.getEmotionAnalytics);
+router.get("/equity-curve", requireAuth, AnalyticsController.getEquityCurve);
 
 module.exports = router;

--- a/server/src/modules/analytics/services/analytics.service.js
+++ b/server/src/modules/analytics/services/analytics.service.js
@@ -247,6 +247,53 @@ const AnalyticsService = {
 
     return { byEmotion, mostCommonWin, mostCommonLoss };
   },
+
+  /**
+   * Equity curve — cumulative P&L over time
+   *
+   * Each point represents the running total of all closed trade P&L
+   * up to and including that date.
+   *
+   * @param {string} userId
+   * @returns {Array} [{ date, cumulativePnl }]
+   */
+  getEquityCurve: async (userId) => {
+    logger.debug("Calculating equity curve", { userId });
+
+    const trades = await AnalyticsRepository.getEquityCurveData(userId);
+
+    if (trades.length === 0) return [];
+
+    let cumulativePnl = 0;
+    const result = [];
+
+    for (const trade of trades) {
+      const pnl = calculateTradePnL(trade);
+      cumulativePnl += pnl;
+
+      const date = new Date(trade.closed_at).toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      });
+
+      // If multiple trades closed on the same day, update the last point
+      // rather than adding a new one — keeps the chart clean
+      if (result.length > 0 && result[result.length - 1].date === date) {
+        result[result.length - 1].cumulativePnl =
+          Math.round(cumulativePnl * 100) / 100;
+      } else {
+        result.push({
+          date,
+          cumulativePnl: Math.round(cumulativePnl * 100) / 100,
+        });
+      }
+    }
+
+    logger.debug("Equity curve calculated", { points: result.length });
+
+    return result;
+  },
 };
 
 module.exports = AnalyticsService;

--- a/server/tests/api/analytics.test.js
+++ b/server/tests/api/analytics.test.js
@@ -292,4 +292,59 @@ describe("Analytics API", () => {
 
     expect(res.status).toBe(401);
   });
+
+  // =========================
+  // Test Case 4.13
+  // Equity curve — empty state
+  // =========================
+  /**
+   * Validates that equity curve returns empty array
+   * when no closed trades exist.
+   */
+  it("returns empty array for equity curve when no closed trades exist", async () => {
+    const res = await request(app)
+      .get("/api/analytics/equity-curve")
+      .set("Cookie", cookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+  });
+
+  // =========================
+  // Test Case 4.14
+  // Equity curve — with data
+  // =========================
+  /**
+   * Validates that equity curve returns cumulative P&L points.
+   * AAPL BUY entry 100 exit 150 qty 1 = $50 profit
+   * Cumulative after one trade = $50
+   */
+  it("returns correct cumulative P&L for equity curve", async () => {
+    await request(app)
+      .post("/api/trades")
+      .set("Cookie", cookie)
+      .send(validTrade());
+
+    const res = await request(app)
+      .get("/api/analytics/equity-curve")
+      .set("Cookie", cookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBeGreaterThan(0);
+    expect(res.body.data[0].date).toBeDefined();
+    expect(res.body.data[0].cumulativePnl).toBe(50);
+  });
+
+  // =========================
+  // Test Case 4.15
+  // Equity curve — auth protection
+  // =========================
+  /**
+   * Validates that equity curve requires authentication.
+   */
+  it("returns 401 for unauthenticated equity curve request", async () => {
+    const res = await request(app).get("/api/analytics/equity-curve");
+
+    expect(res.status).toBe(401);
+  });
 });


### PR DESCRIPTION
## Summary

Implements the Equity Curve story. Adds a `GET /api/analytics/equity-curve`
endpoint that returns cumulative P&L over time. A line chart is displayed
on the dashboard above the P&L bar chart showing the overall trajectory
of trading performance.

## Changes

### Backend
- `analytics.repository.js` — added `getEquityCurveData` query
- `analytics.service.js` — added `getEquityCurve` calculating running
  cumulative P&L per day, merging multiple trades on the same day into
  a single point
- `analytics.controller.js` — added `getEquityCurve` handler
- `analytics.routes.js` — added `GET /equity-curve` route

### Tests
- `analytics.test.js` — added tests 4.13 – 4.15

### Frontend
- `Dashboard.jsx` — added Equity Curve section above P&L bar chart
  using Recharts LineChart. Line color reflects overall P&L (green
  positive, red negative). Custom tooltip shows date and cumulative
  P&L. Fetched alongside existing analytics on load.

## Test Coverage

| Test | Description |
|------|-------------|
| 4.13 | Returns empty array when no closed trades exist |
| 4.14 | Returns correct cumulative P&L points |
| 4.15 | Returns 401 for unauthenticated requests |

**Total: 57 → 60 passing tests**